### PR TITLE
Update documentation for project guidelines and standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 - Swift：Swift 6.0+
 
 平台支持（按项目选择）：
-- iOS 17.0+、iPadOS 17.0+、macOS 14.0+、visionOS 2.0+
+- macOS 26.0+、visionOS 26.0+
 
 ### 设计原则
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# 仓库指南
+# 项目开发规范与指南
 
 ## 项目结构与模块组织
 
@@ -9,49 +9,6 @@
 - 单元测试：`LonelyPianistTests/`（Swift Testing）
 - visionOS 相关：`LonelyPianistAVP/`、`LonelyPianistAVPTests/`（scheme：`LonelyPianistAVP`）
 - AI 后端工作区：`piano_dialogue_server/`（本机 Python 环境）
-- 规范与知识库：`.github/deepwiki/`（优先参考 `.github/deepwiki/references/开发规范.md`）
-
-## 构建、测试和开发命令
-
-打开工程：
-
-```bash
-open LonelyPianist.xcodeproj
-```
-
-命令行构建（macOS Debug）：
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug build
-```
-
-运行单测（macOS Debug）：
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug test
-```
-
-visionOS（可选）：先查看可用 destination，再构建/测试 `LonelyPianistAVP`：
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -showdestinations
-```
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -configuration Debug build
-```
-
-Piano Dialogue 后端（可选）：在独立终端启动本机服务（默认 `127.0.0.1:8765`）：
-
-```bash
-cd piano_dialogue_server
-python3.12 -m venv .venv
-source .venv/bin/activate
-pip install -U pip
-pip install -r requirements.txt
-cd server
-../.venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port 8765
-```
 
 ## 代码风格与命名规范
 
@@ -66,21 +23,15 @@ cd server
 - 新增 Service Protocol 时提供最少 1 个测试替身（成功/失败各覆盖）；涉及时间窗口/节流时把时间源做成可注入依赖，避免真实等待。
 - 提交前手测：权限请求与状态刷新、Start Listening 后 Sources/MIDI Events 更新、Single/Chord/Melody 映射各验证一次、Profile 持久化（重启仍保留）。
 
-## 提交与 Pull Request 规范
+## 开发规范
 
-- Commit message：优先 `feat:` / `fix:` / `refactor:` / `test:`，与 `.github/features/**` 的任务可追加标识（如 `P2-T1`）。
-- PR 描述包含：动机、关键改动点、验证方式（命令 + 手测项）；涉及 UI 变更附截图或录屏。
-
-
-# Apple App 开发规范 for AI（Swift/SwiftUI 基线，唯一源）
-
-本文件是 `swift-dev` 下“开发规范”的**唯一真源**（single source of truth）。
+来源：从 `swift-dev` 的 Apple/SwiftUI 开发规范整理而来，并按本仓库（macOS + SwiftUI + Swift Testing）做了少量对齐。
 
 使用方式：
-- **先看 repo 自己的规范**（例如 `AGENTS.md` / `CONTRIBUTING.md` / `README` 中的架构约定）；项目内规范优先级更高。
-- 本文用于补齐“默认假设”和“常见决策边界”（尤其是 MVVM、依赖注入、Observation、测试策略与日志规范）。
+- 本规范优先级低于本仓库代码与工程实际约束（例如测试框架、可用平台）。
+- 用于补齐“默认假设”和“常见决策边界”（尤其是 MVVM、依赖注入、Observation、测试策略与日志规范）。
 
-## 核心技术栈
+### 核心技术栈
 
 - 架构模式：MVVM (Model-View-ViewModel)
 - 编程范式：Protocol-Oriented Programming（面向协议）
@@ -92,7 +43,7 @@ cd server
 平台支持（按项目选择）：
 - iOS 17.0+、iPadOS 17.0+、macOS 14.0+、visionOS 2.0+
 
-## 设计原则
+### 设计原则
 
 - 组合优于继承：优先依赖注入
 - 接口优于单例：利于测试与替换
@@ -104,7 +55,7 @@ cd server
 - YAGNI：不为不确定未来预埋
 - DRY + WET：避免重复，但别过早抽象（通常重复 2–3 次后再抽）
 
-## MVVM 架构规范
+### MVVM 架构规范
 
 职责划分：
 - **Model**：纯数据结构；不放 UI 逻辑（避免引用 SwiftUI/Observation/Combine）
@@ -112,7 +63,7 @@ cd server
 - **View**：渲染与交互绑定；不写业务逻辑；不直接访问数据库/网络
 - **Service/Repository**：网络、持久化、文件 IO 等副作用；优先协议抽象 + 注入
 
-### 模块化建议（可选，不是硬性要求）
+#### 模块化建议（可选，不是硬性要求）
 
 当项目允许时，可把“逻辑层”下沉到 SwiftPM，以便：
 - 更快的单元测试（测试执行方式按项目工具链约束选择）
@@ -127,33 +78,33 @@ cd server
 
 注意：若项目本身不采用 SwiftPM 拆分（例如以 Xcode 项目为主），仍然可以遵循上述“职责划分 + 依赖注入 + 单向依赖”的原则。
 
-### ViewModel 规范（Observation 优先）
+#### ViewModel 规范（Observation 优先）
 
 - iOS 17+ / macOS 14+：优先 `@Observable` / `@Bindable`
 - 避免单例：不要用 `static let shared`
 - 依赖注入优先：初始化参数或 `.environment(...)`
 - 不使用 `ObservableObject` / `@Published` / `@StateObject` / `@ObservedObject` / `@EnvironmentObject`（统一用 Observation 体系）。
 
-### SwiftUI 事件处理
+#### SwiftUI 事件处理
 
 - 优先使用 `.onChange(of:) {}` 的无参数重载。
 - 只有确实需要 `oldValue` / `newValue` 时，才使用带两个参数的重载；不要默认写 `.onChange(of:) { _, _ in }`。
 
-## 协议驱动开发
+### 协议驱动开发
 
 原则：
 1. 先定义协议，再实现类型
 2. 用协议消除类型分支（减少 `switch` 的维护成本）
 3. 新增能力优先“增加实现”而不是“修改中心分发器”
 
-## 测试与调试
+### 测试与调试
 
 工具约束（`swift-dev` 默认）：
 - 本目录下涉及 build/test/run 的操作，统一使用原生 `xcodebuild`。
 - 涉及 Simulator/Device 与日志相关的操作，按需使用原生 `xcrun simctl` / `log stream` 等系统工具。
 
 单元测试优先级建议：
-- **逻辑层 / ViewModel / UI 层**：统一用 XCTest（通过 `xcodebuild test` 跑）
+- **逻辑层 / ViewModel / UI 层**：优先用单元测试覆盖（本仓库采用 Swift Testing；通过 `xcodebuild test` 跑）
 
 调试与日志：
 - 日志用 `os.Logger`，明确 `subsystem` 与 `category`，便于过滤与定位

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,34 +2,71 @@
 
 ## 项目结构与模块组织
 
-本仓库是一个 macOS 桌面应用（SwiftUI + CoreMIDI + SwiftData）。主代码位于 `LonelyPianist/`，按 MVVM 与服务分层组织：
+本仓库是一个 macOS 桌面应用（SwiftUI + CoreMIDI + SwiftData）。
 
-- `Models/`：领域模型与存储实体（MIDI 事件、映射规则、Profile）。
-- `Services/`：基础设施与业务服务（MIDI、输入注入、权限、映射引擎、存储仓储）。
-- `ViewModels/`：状态编排与业务流程入口（当前主要是 `LonelyPianistViewModel`）。
-- `Views/`：主窗口、控制面板与功能页 UI。
-- `Utilities/`：解析器与默认配置工厂。
-- `.github/deepwiki/`：仓库知识库（业务入口 + 技术细节）。
+- 主工程：`LonelyPianist.xcodeproj`
+- App 代码：`LonelyPianist/`（按 MVVM + Services 分层：`Models/`、`Services/`、`ViewModels/`、`Views/`、`Utilities/`）
+- 单元测试：`LonelyPianistTests/`（Swift Testing）
+- visionOS 相关：`LonelyPianistAVP/`、`LonelyPianistAVPTests/`（scheme：`LonelyPianistAVP`）
+- AI 后端工作区：`piano_dialogue_server/`（本机 Python 环境）
+- 规范与知识库：`.github/deepwiki/`（优先参考 `.github/deepwiki/references/开发规范.md`）
 
-- If using XcodeBuildMCP, use the installed XcodeBuildMCP skill before calling XcodeBuildMCP tools.
+## 构建、测试和开发命令
+
+打开工程：
+
+```bash
+open LonelyPianist.xcodeproj
+```
+
+命令行构建（macOS Debug）：
+
+```bash
+xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug build
+```
+
+运行单测（macOS Debug）：
+
+```bash
+xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug test
+```
+
+visionOS（可选）：先查看可用 destination，再构建/测试 `LonelyPianistAVP`：
+
+```bash
+xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -showdestinations
+```
+
+```bash
+xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -configuration Debug build
+```
+
+Piano Dialogue 后端（可选）：在独立终端启动本机服务（默认 `127.0.0.1:8765`）：
+
+```bash
+cd piano_dialogue_server
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+cd server
+../.venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port 8765
+```
 
 ## 代码风格与命名规范
 
-- 以 `.github/deepwiki/references/开发规范.md` 为准：MVVM、面向协议、依赖注入。
-- 统一使用 `@Observable`（macOS 14+），避免 `ObservableObject` 旧式写法。
-- 命名遵循语义化：类型 `PascalCase`，变量/函数 `camelCase`，协议以 `Protocol` 结尾，服务实现以 `Service` 结尾。
-- View 保持展示职责，业务逻辑放入 ViewModel，跨模块能力放入 Service。
+- 统一使用 `@Observable`（macOS 14+），避免 `ObservableObject`。
+- 命名：类型 `PascalCase`；变量/函数 `camelCase`；协议以 `Protocol` 结尾；实现以 `Service` 结尾。
+- View 只负责展示；状态编排与业务流程放 `ViewModels/`；跨模块能力下沉到 `Services/`，依赖通过注入传递。
+- SwiftUI 事件：不需要旧/新值时优先 `.onChange(of:) { ... }` 无参数重载，避免 `(_, _)` 形式的冗余闭包签名。
 
 ## 测试指南
 
-提交前至少完成以下手测：
+- 测试框架：Swift Testing（`import Testing` + `@Test` + `#expect`），新增文件放 `LonelyPianistTests/`，命名 `*Tests.swift`。
+- 新增 Service Protocol 时提供最少 1 个测试替身（成功/失败各覆盖）；涉及时间窗口/节流时把时间源做成可注入依赖，避免真实等待。
+- 提交前手测：权限请求与状态刷新、Start Listening 后 Sources/MIDI Events 更新、Single/Chord/Melody 映射各验证一次、Profile 持久化（重启仍保留）。
 
-1. 权限流程：未授权时按钮可触发请求，授权后状态可自动刷新。
-2. MIDI 流程：Start Listening 后 `Sources` 与 `MIDI Events` 有变化。
-3. 映射流程：Single Key、Chord、Melody 三类规则至少各验证一次。
-4. 持久化流程：新建或编辑 Profile 后重启应用仍保留。
+## 提交与 Pull Request 规范
 
-新增复杂逻辑时，优先补充 **Swift Testing** 单元测试（建议在 `LonelyPianistTests/` 下按功能命名如 `DefaultMappingEngineTests.swift`）。
-如果引入新的 Service Protocol，请同时提供至少一个 mock 测试双（test double），覆盖成功路径与失败路径。涉及状态轮询、时间窗口和节流逻辑时，优先把时间源抽象为可注入依赖，避免测试依赖真实等待。
-
-> 注：本仓库测试采用 **Swift Testing**（`import Testing` + `@Test` + `#expect`），不是 XCTest。新增测试文件请按现有风格放在 `LonelyPianistTests/` 下。
+- Commit message：优先 `feat:` / `fix:` / `refactor:` / `test:`，与 `.github/features/**` 的任务可追加标识（如 `P2-T1`）。
+- PR 描述包含：动机、关键改动点、验证方式（命令 + 手测项）；涉及 UI 变更附截图或录屏。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,90 @@ cd server
 
 - Commit message：优先 `feat:` / `fix:` / `refactor:` / `test:`，与 `.github/features/**` 的任务可追加标识（如 `P2-T1`）。
 - PR 描述包含：动机、关键改动点、验证方式（命令 + 手测项）；涉及 UI 变更附截图或录屏。
+
+
+# Apple App 开发规范 for AI（Swift/SwiftUI 基线，唯一源）
+
+本文件是 `swift-dev` 下“开发规范”的**唯一真源**（single source of truth）。
+
+使用方式：
+- **先看 repo 自己的规范**（例如 `AGENTS.md` / `CONTRIBUTING.md` / `README` 中的架构约定）；项目内规范优先级更高。
+- 本文用于补齐“默认假设”和“常见决策边界”（尤其是 MVVM、依赖注入、Observation、测试策略与日志规范）。
+
+## 核心技术栈
+
+- 架构模式：MVVM (Model-View-ViewModel)
+- 编程范式：Protocol-Oriented Programming（面向协议）
+- UI：SwiftUI、RealityKit（按需）
+- 状态管理：Observation（`@Observable` / `@Bindable`）；必要时使用 Swift Concurrency；仅在需要 Publisher 管道时引入 Combine
+- 持久化：SwiftData（按需）
+- Swift：Swift 6.0+
+
+平台支持（按项目选择）：
+- iOS 17.0+、iPadOS 17.0+、macOS 14.0+、visionOS 2.0+
+
+## 设计原则
+
+- 组合优于继承：优先依赖注入
+- 接口优于单例：利于测试与替换
+- 显式优于隐式：数据流与依赖清晰可追踪
+- 协议驱动：优先“新增实现”而不是“改 switch”
+
+工程简洁性：
+- KISS：能简单就别复杂
+- YAGNI：不为不确定未来预埋
+- DRY + WET：避免重复，但别过早抽象（通常重复 2–3 次后再抽）
+
+## MVVM 架构规范
+
+职责划分：
+- **Model**：纯数据结构；不放 UI 逻辑（避免引用 SwiftUI/Observation/Combine）
+- **ViewModel**：业务流程编排、状态管理、数据转换；不直接做 UI 操作；避免隐藏单例依赖
+- **View**：渲染与交互绑定；不写业务逻辑；不直接访问数据库/网络
+- **Service/Repository**：网络、持久化、文件 IO 等副作用；优先协议抽象 + 注入
+
+### 模块化建议（可选，不是硬性要求）
+
+当项目允许时，可把“逻辑层”下沉到 SwiftPM，以便：
+- 更快的单元测试（测试执行方式按项目工具链约束选择）
+- 更强的可复用性与跨平台能力
+
+建议依赖方向保持单向：
+`SwiftUI 层 → ViewModel → Services → Models`
+
+建议拆分：
+- `Models` target：纯数据结构，尽量零依赖
+- `Services` target：业务逻辑与基础设施，依赖 `Models`
+
+注意：若项目本身不采用 SwiftPM 拆分（例如以 Xcode 项目为主），仍然可以遵循上述“职责划分 + 依赖注入 + 单向依赖”的原则。
+
+### ViewModel 规范（Observation 优先）
+
+- iOS 17+ / macOS 14+：优先 `@Observable` / `@Bindable`
+- 避免单例：不要用 `static let shared`
+- 依赖注入优先：初始化参数或 `.environment(...)`
+- 不使用 `ObservableObject` / `@Published` / `@StateObject` / `@ObservedObject` / `@EnvironmentObject`（统一用 Observation 体系）。
+
+### SwiftUI 事件处理
+
+- 优先使用 `.onChange(of:) {}` 的无参数重载。
+- 只有确实需要 `oldValue` / `newValue` 时，才使用带两个参数的重载；不要默认写 `.onChange(of:) { _, _ in }`。
+
+## 协议驱动开发
+
+原则：
+1. 先定义协议，再实现类型
+2. 用协议消除类型分支（减少 `switch` 的维护成本）
+3. 新增能力优先“增加实现”而不是“修改中心分发器”
+
+## 测试与调试
+
+工具约束（`swift-dev` 默认）：
+- 本目录下涉及 build/test/run 的操作，统一使用原生 `xcodebuild`。
+- 涉及 Simulator/Device 与日志相关的操作，按需使用原生 `xcrun simctl` / `log stream` 等系统工具。
+
+单元测试优先级建议：
+- **逻辑层 / ViewModel / UI 层**：统一用 XCTest（通过 `xcodebuild test` 跑）
+
+调试与日志：
+- 日志用 `os.Logger`，明确 `subsystem` 与 `category`，便于过滤与定位

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,24 @@
 
 调试与日志：
 - 日志用 `os.Logger`，明确 `subsystem` 与 `category`，便于过滤与定位
+
+### Apple 文档查询（XCDocs，强烈推荐频繁使用）
+
+当涉及 SwiftUI / RealityKit / ARKit / visionOS 的新 API、不确定的符号形状、或 2D/3D 结合模式时，优先用本机 `xcdocs` 查询确认，再落到实现与计划中（避免靠记忆猜 API）。
+
+推荐流程：
+
+1. 粗搜：`xcdocs search "<query>" --omit-content --json --limit 10`
+2. 精读：对结果中的 `documents[].uri` 执行 `xcdocs get <uri> --json`
+3. 落盘：在对应的 `plan-px.md` 写清“采用的官方路径 + 对应 uri”，并在实现中按文档形状写代码（必要时加 availability/降级策略）。
+
+对本仓库的高频查询主题：
+
+- 2D/3D 结合：RealityView attachments、SwiftUI ornaments
+- ImmersiveSpace 打开/关闭与窗口/沉浸空间分工
+- HandTrackingProvider（权限/可用性/降级路径）
+
+### visionOS（LonelyPianistAVP）工程规范对齐
+
+- `LonelyPianistAVP/` 的新增代码同样遵守本仓库 MVVM + Services 分层与命名规范（尽量按 `Models/`、`Services/`、`ViewModels/`、`Views/` 组织；不要把业务逻辑堆在 View 里）。
+- 事件处理与 Observation 体系同样适用：优先 `@Observable/@Bindable`，并优先使用 `.onChange(of:) {}` 的无参数重载。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,6 @@
 
 ## 代码风格与命名规范
 
-- 统一使用 `@Observable`（macOS 14+），避免 `ObservableObject`。
 - 命名：类型 `PascalCase`；变量/函数 `camelCase`；协议以 `Protocol` 结尾；实现以 `Service` 结尾。
 - View 只负责展示；状态编排与业务流程放 `ViewModels/`；跨模块能力下沉到 `Services/`，依赖通过注入传递。
 - SwiftUI 事件：不需要旧/新值时优先 `.onChange(of:) { ... }` 无参数重载，避免 `(_, _)` 形式的冗余闭包签名。
@@ -23,7 +22,7 @@
 - 新增 Service Protocol 时提供最少 1 个测试替身（成功/失败各覆盖）；涉及时间窗口/节流时把时间源做成可注入依赖，避免真实等待。
 - 提交前手测：权限请求与状态刷新、Start Listening 后 Sources/MIDI Events 更新、Single/Chord/Melody 映射各验证一次、Profile 持久化（重启仍保留）。
 
-## 开发规范
+## 开发规范（详细）
 
 来源：从 `swift-dev` 的 Apple/SwiftUI 开发规范整理而来，并按本仓库（macOS + SwiftUI + Swift Testing）做了少量对齐。
 

--- a/README.md
+++ b/README.md
@@ -85,41 +85,6 @@
 
 ---
 
-## 🧑‍💻 开发与启动（从源码）
-
-环境要求：
-
-- macOS 14+
-- Xcode 16+（推荐用最新稳定版）
-
-启动方式二选一：
-
-1) 用 Xcode 打开工程：
-
-```bash
-open LonelyPianist.xcodeproj
-```
-
-2) 用脚本一键 build + open（推荐）：
-
-```bash
-.github/scripts/build-open.sh
-```
-
-验证构建（Debug）：
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug build
-```
-
-运行单测：
-
-```bash
-xcodebuild -project LonelyPianist.xcodeproj -scheme LonelyPianist -configuration Debug test
-```
-
----
-
 ## 🤖 Piano Dialogue（AI 钢琴对话模式）
 
 > Turn-based：你弹一段 → 停顿 → AI 回一段（AI 音符会用橙色显示，并保存到 Recorder 的同一个 take 内）。


### PR DESCRIPTION
Revise the documentation to simplify structure, remove redundant content, and align with Apple development standards. Update platform support information and add guidelines for visionOS and Apple documentation querying processes.