### PR TITLE
Add functionality to load bundled sample score and tests

### DIFF
--- a/LonelyPianistAVP/AppModel.swift
+++ b/LonelyPianistAVP/AppModel.swift
@@ -117,6 +117,37 @@ class AppModel {
         }
     }
 
+    func loadBundledSampleScoreIfNeeded() {
+        guard importedFile == nil, importedSteps.isEmpty else { return }
+
+        let sampleSubdirectory = "Resources/SampleScores/坂本龙一"
+        let sampleMusicXMLFileName = "Opus – Ryuichi Sakamoto (Piano Transcription).musicxml"
+
+        let bundle = Bundle(for: AppModel.self)
+        guard let musicXMLURL = bundle.url(
+            forResource: sampleMusicXMLFileName,
+            withExtension: nil,
+            subdirectory: sampleSubdirectory
+        ) ?? bundle.url(forResource: sampleMusicXMLFileName, withExtension: nil) else {
+            return
+        }
+
+        do {
+            let score = try parser.parse(fileURL: musicXMLURL)
+            let buildResult = stepBuilder.buildSteps(from: score)
+            setImportedSteps(
+                buildResult.steps,
+                file: ImportedMusicXMLFile(
+                    fileName: sampleMusicXMLFileName,
+                    storedURL: musicXMLURL,
+                    importedAt: Date()
+                )
+            )
+        } catch {
+            return
+        }
+    }
+
     func loadStoredCalibrationIfPossible() {
         do {
             guard let stored = try worldAnchorCalibrationStore.load() else { return }

--- a/LonelyPianistAVP/LonelyPianistAVPApp.swift
+++ b/LonelyPianistAVP/LonelyPianistAVPApp.swift
@@ -10,6 +10,9 @@ struct LonelyPianistAVPApp: App {
     init() {
         let appModel = AppModel()
         appModel.loadStoredCalibrationIfPossible()
+        Task { @MainActor in
+            appModel.loadBundledSampleScoreIfNeeded()
+        }
         _appModel = State(initialValue: appModel)
         _homeViewModel = State(initialValue: HomeViewModel(appModel: appModel))
         _arGuideViewModel = State(initialValue: ARGuideViewModel(appModel: appModel))

--- a/LonelyPianistAVPTests/BundledSampleScoreTests.swift
+++ b/LonelyPianistAVPTests/BundledSampleScoreTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import LonelyPianistAVP
+
+@Test
+func bundledSampleScoreResourcesExistAndParse() throws {
+    let bundle = Bundle(for: AppModel.self)
+    let subdirectory = "Resources/SampleScores/坂本龙一"
+
+    let musicXMLFileName = "Opus – Ryuichi Sakamoto (Piano Transcription).musicxml"
+    let pdfFileName = "Opus – Ryuichi Sakamoto (Piano Transcription).pdf"
+    let mp3FileName = "Opus – Ryuichi Sakamoto (Piano Transcription).mp3"
+
+    let musicXMLURL = bundle.url(
+        forResource: musicXMLFileName,
+        withExtension: nil,
+        subdirectory: subdirectory
+    ) ?? bundle.url(forResource: musicXMLFileName, withExtension: nil)
+    #expect(musicXMLURL != nil)
+
+    let pdfURL = bundle.url(forResource: pdfFileName, withExtension: nil, subdirectory: subdirectory)
+        ?? bundle.url(forResource: pdfFileName, withExtension: nil)
+    #expect(pdfURL != nil)
+
+    let mp3URL = bundle.url(forResource: mp3FileName, withExtension: nil, subdirectory: subdirectory)
+        ?? bundle.url(forResource: mp3FileName, withExtension: nil)
+    #expect(mp3URL != nil)
+
+    guard let musicXMLURL else { return }
+    let score = try MusicXMLParser().parse(fileURL: musicXMLURL)
+    let buildResult = PracticeStepBuilder().buildSteps(from: score)
+    #expect(buildResult.steps.isEmpty == false)
+}


### PR DESCRIPTION
Implement a feature to load a bundled sample score when no file is imported, along with corresponding tests to ensure the resources exist and are parsed correctly.