### PR TITLE
修复 AVP AR 引导坐标系与高亮对齐问题

### DIFF
--- a/.github/deepwiki/glossary.md
+++ b/.github/deepwiki/glossary.md
@@ -14,6 +14,8 @@
 | `DialogueNote` | Swift 和 Python 共享的音符契约 |
 | `PracticeStep` | AVP 练习推进单元 |
 | `DataProviderState` | AR tracking provider 的运行状态 |
+| `KeyboardFrame` | 从 A0/C8 推导的键盘局部坐标系（A0 为原点，+X 指向 C8） |
+| `frontEdgeToKeyCenterLocalZ` | 在 keyboard-local 中，前沿线（z=0）到按键中心线的 Z 偏移（通常为 ±keyDepth/2） |
 
 ## 存储术语
 | 术语 | 定义 |

--- a/.github/deepwiki/modules/lonelypianist-avp-calibration.md
+++ b/.github/deepwiki/modules/lonelypianist-avp-calibration.md
@@ -11,12 +11,21 @@
 | `CalibrationPointCaptureService` | 准星稳定与锚点 ID 记录 |
 | `WorldAnchorCalibrationStore` | JSON 持久化 |
 | `PianoKeyGeometryService` | 根据校准生成 88 键区域 |
+| `KeyboardFrame` | 从 A0/C8 推导键盘局部坐标系（用于渲染与按键检测） |
 
 ## 行为
 - `saveCalibrationIfPossible()` 会拒绝不完整校准。
 - 保存后会 reset capture state。
 - `beginCalibrationRecapture()` 会清理临时锚点。
 - `resolveRuntimeCalibrationFromTrackedAnchors()` 会检查 anchor 是否存在、是否 tracked、是否足够远。
+- runtime calibration 会把 **A0/C8 解释为琴键“前沿线”**（keyboard-local `z = 0`），并基于 `DeviceAnchor` 判断琴键内部方向，从而得到 `frontEdgeToKeyCenterLocalZ`（通常是 `± keyDepth/2`）。
+
+## 坐标系约定（KeyboardFrame）
+
+- 原点：A0（投影到 `planeHeight`）。
+- +X：从 A0 指向 C8（水平投影）。
+- +Y：世界向上。
+- +Z：按右手系推导（满足 `cross(x, y) == z`）。注意 +Z 未必“朝向用户”，需结合设备位姿判定哪一侧是琴键内部。
 
 ## 失败类型
 | 失败 | 含义 |
@@ -25,6 +34,7 @@
 | `anchorMissing` | 锚点没在当前环境恢复 |
 | `anchorNotTracked` | 锚点存在但未跟踪 |
 | `anchorsTooClose` | A0/C8 距离过近 |
+| `devicePoseUnavailable` | 设备位姿暂不可用，无法判定前后方向 |
 
 ## 调试抓手
 - `calibrationStatusMessage`
@@ -35,4 +45,3 @@
 
 ## Coverage Gaps
 - 校准流程的空间交互仍依赖手工验证，缺少沉浸式 UI 自动化。
-

--- a/.github/deepwiki/modules/lonelypianist-avp-practice.md
+++ b/.github/deepwiki/modules/lonelypianist-avp-practice.md
@@ -11,12 +11,15 @@
 | `ChordAttemptAccumulator` | 和弦尝试匹配 |
 | `SoundFontPracticeNoteAudioPlayer` | 练习音色播放 |
 | `PracticeMIDINoteOutputProtocol` | note on/off 输出 |
+| `PianoGuideOverlayController` | RealityKit 空间高亮（键位提示） |
 
 ## 行为
 - `handleFingerTipPositions` 根据 key regions 检测按键。
 - 匹配成功会进入 correct feedback，并在 autoplay 关闭时推进下一步。
 - autoplay 会按 note span / pedal / fermata 驱动。
 - `skip()` 可手动跳步。
+- 空间高亮基于 `PianoKeyRegion.center` 放置；由于 A0/C8 语义为“前沿线”，key center 会通过 `frontEdgeToKeyCenterLocalZ` 从前沿线偏移到按键中心线。
+- 当前高亮方块不再额外抬高（贴 keyboard-local `Y = 0`），以减少“悬浮”错觉。
 
 ## 状态
 | 状态 | 含义 |
@@ -33,7 +36,8 @@
 - `audioErrorMessage`
 - `currentMusicXMLAttributeSummaryText`
 
+## 调试开关
+- `debugKeyboardAxesOverlayEnabled`：显示键盘坐标轴（含 X/Y/Z 标注），便于确认 keyboard frame 是否正确对齐 A0/C8。
 
 ## Coverage Gaps
 - 视觉反馈和空间布局仍主要依赖手工体验，不是纯逻辑测试就能完全覆盖。
-

--- a/LonelyPianistAVP/AGENTS.md
+++ b/LonelyPianistAVP/AGENTS.md
@@ -308,6 +308,13 @@ func load() throws(LoadError) { ... }
 - **Documentation:** public API 使用清晰命名并写必要的 doc comments。
 - **交付格式:** 遵循下方约定的输出格式。
 
+### 坐标系与校准语义（本仓库约定）
+
+- **A0/C8 的语义是“琴键前沿线”**（keyboard-local `z = 0`），不是按键中心线。
+- 按键中心线通过 `frontEdgeToKeyCenterLocalZ` 表达（通常为 `± keyDepth/2`）；偏移正负需要用 `DeviceAnchor`（`WorldTrackingProvider.queryDeviceAnchor(atTimestamp:)`）判定“用户在键盘哪一侧”。
+- **KeyboardFrame 坐标轴约定**：A0 为原点，+X 指向 C8（水平投影），+Y 向上，+Z 右手系推导（满足 `cross(x, y) == z`）。
+- 练习设置里可开启 `debugKeyboardAxesOverlayEnabled` 显示键盘坐标轴（含 X/Y/Z 标注），用于排查“方向反了/整体偏移”等问题。
+
 ## 推荐代码模式
 
 ### 带错误处理的 Model 加载

--- a/LonelyPianistAVP/AppModel.swift
+++ b/LonelyPianistAVP/AppModel.swift
@@ -305,7 +305,8 @@ class AppModel {
                 let zAxis = frame.zAxisWorld
                 // If the device is on +Z side, keyboard interior is -Z; otherwise interior is +Z.
                 let interiorIsNegativeZ = simd_dot(toDeviceDir, zAxis) > 0
-                frontEdgeToKeyCenterLocalZ = (interiorIsNegativeZ ? -1 : 1) * (PianoKeyGeometryService.keyDepthMeters / 2)
+                frontEdgeToKeyCenterLocalZ = (interiorIsNegativeZ ? -1 : 1) *
+                    (PianoKeyGeometryService.keyDepthMeters / 2)
             } else {
                 // Degenerate; fall back to "no offset" rather than guessing a direction.
                 frontEdgeToKeyCenterLocalZ = 0

--- a/LonelyPianistAVP/AppModel.swift
+++ b/LonelyPianistAVP/AppModel.swift
@@ -12,6 +12,7 @@ class AppModel {
         case anchorMissing(id: UUID)
         case anchorNotTracked(id: UUID)
         case anchorsTooClose(distanceMeters: Float)
+        case devicePoseUnavailable
     }
 
     let immersiveSpaceID = "ImmersiveSpace"
@@ -273,10 +274,41 @@ class AppModel {
             return .anchorsTooClose(distanceMeters: distanceMeters)
         }
 
+        let planeY = (a0Point.y + c8Point.y) / 2
+        var adjustedA0 = a0Point
+        var adjustedC8 = c8Point
+
+        // Interpret the calibrated A0/C8 as the keyboard's front edge line.
+        // Shift the runtime calibration points by half key depth towards the keyboard interior so that
+        // the highlight boxes' *front faces* align with the calibrated line (instead of their centers).
+        if let frame = KeyboardFrame(a0World: a0Point, c8World: c8Point, planeHeight: planeY) {
+            let timestamp = ProcessInfo.processInfo.systemUptime
+            guard
+                let deviceAnchor = arTrackingService.worldTrackingProvider.queryDeviceAnchor(atTimestamp: timestamp),
+                deviceAnchor.isTracked
+            else {
+                return .devicePoseUnavailable
+            }
+            let deviceTransform = deviceAnchor.originFromAnchorTransform
+            let devicePos = SIMD3<Float>(deviceTransform.columns.3.x, deviceTransform.columns.3.y, deviceTransform.columns.3.z)
+            let origin = frame.originWorld
+            let toDevice = SIMD3<Float>(devicePos.x - origin.x, 0, devicePos.z - origin.z)
+            let toDeviceLen = simd_length(toDevice)
+            if toDeviceLen > 1e-4 {
+                let toDeviceDir = toDevice / toDeviceLen
+                let zAxis = frame.zAxisWorld
+                // If the device is on +Z side, interior is -Z; otherwise interior is +Z.
+                let interiorDir = simd_dot(toDeviceDir, zAxis) > 0 ? -zAxis : zAxis
+                let offset = interiorDir * (PianoKeyGeometryService.keyDepthMeters / 2)
+                adjustedA0 = a0Point + offset
+                adjustedC8 = c8Point + offset
+            }
+        }
+
         calibration = PianoCalibration(
-            a0: a0Point,
-            c8: c8Point,
-            planeHeight: (a0Point.y + c8Point.y) / 2,
+            a0: adjustedA0,
+            c8: adjustedC8,
+            planeHeight: planeY,
             whiteKeyWidth: storedCalibration.whiteKeyWidth
         )
 

--- a/LonelyPianistAVP/AppModel.swift
+++ b/LonelyPianistAVP/AppModel.swift
@@ -275,12 +275,12 @@ class AppModel {
         }
 
         let planeY = (a0Point.y + c8Point.y) / 2
-        var adjustedA0 = a0Point
-        var adjustedC8 = c8Point
 
-        // Interpret the calibrated A0/C8 as the keyboard's front edge line.
-        // Shift the runtime calibration points by half key depth towards the keyboard interior so that
-        // the highlight boxes' *front faces* align with the calibrated line (instead of their centers).
+        // Interpret calibrated A0/C8 as the keyboard's *front edge line* (keyboard-local z = 0).
+        // We still need to place highlights and hit regions at key centers, which are offset by
+        // ±keyDepth/2 along the keyboard-local Z axis. Determine the correct sign using the current
+        // device pose (which side the user is on).
+        let frontEdgeToKeyCenterLocalZ: Float
         if let frame = KeyboardFrame(a0World: a0Point, c8World: c8Point, planeHeight: planeY) {
             let timestamp = ProcessInfo.processInfo.systemUptime
             guard
@@ -289,27 +289,37 @@ class AppModel {
             else {
                 return .devicePoseUnavailable
             }
+
             let deviceTransform = deviceAnchor.originFromAnchorTransform
-            let devicePos = SIMD3<Float>(deviceTransform.columns.3.x, deviceTransform.columns.3.y, deviceTransform.columns.3.z)
+            let devicePos = SIMD3<Float>(
+                deviceTransform.columns.3.x,
+                deviceTransform.columns.3.y,
+                deviceTransform.columns.3.z
+            )
+
             let origin = frame.originWorld
             let toDevice = SIMD3<Float>(devicePos.x - origin.x, 0, devicePos.z - origin.z)
             let toDeviceLen = simd_length(toDevice)
             if toDeviceLen > 1e-4 {
                 let toDeviceDir = toDevice / toDeviceLen
                 let zAxis = frame.zAxisWorld
-                // If the device is on +Z side, interior is -Z; otherwise interior is +Z.
-                let interiorDir = simd_dot(toDeviceDir, zAxis) > 0 ? -zAxis : zAxis
-                let offset = interiorDir * (PianoKeyGeometryService.keyDepthMeters / 2)
-                adjustedA0 = a0Point + offset
-                adjustedC8 = c8Point + offset
+                // If the device is on +Z side, keyboard interior is -Z; otherwise interior is +Z.
+                let interiorIsNegativeZ = simd_dot(toDeviceDir, zAxis) > 0
+                frontEdgeToKeyCenterLocalZ = (interiorIsNegativeZ ? -1 : 1) * (PianoKeyGeometryService.keyDepthMeters / 2)
+            } else {
+                // Degenerate; fall back to "no offset" rather than guessing a direction.
+                frontEdgeToKeyCenterLocalZ = 0
             }
+        } else {
+            frontEdgeToKeyCenterLocalZ = 0
         }
 
         calibration = PianoCalibration(
-            a0: adjustedA0,
-            c8: adjustedC8,
+            a0: a0Point,
+            c8: c8Point,
             planeHeight: planeY,
-            whiteKeyWidth: storedCalibration.whiteKeyWidth
+            whiteKeyWidth: storedCalibration.whiteKeyWidth,
+            frontEdgeToKeyCenterLocalZ: frontEdgeToKeyCenterLocalZ
         )
 
         return .resolved

--- a/LonelyPianistAVP/Models/Calibration/KeyboardFrame.swift
+++ b/LonelyPianistAVP/Models/Calibration/KeyboardFrame.swift
@@ -20,11 +20,13 @@ struct KeyboardFrame {
 
         let yAxis = SIMD3<Float>(0, 1, 0)
 
-        // Use the plan's z-axis convention `cross(worldUp, xAxisCandidate)` (horizontal),
-        // then recompute x from (y,z) to guarantee a right-handed orthonormal basis:
-        // cross(x, y) == z.
+        // Build a right-handed, horizontal basis:
+        // - x points A0 -> C8 (projected onto XZ)
+        // - y is world up
+        // - z is derived so that cross(x, y) == z
+        // Then recompute x from (y,z) to guarantee orthonormality.
         let xAxisProjected = xCandidate / xLen
-        let zAxis = simd_normalize(simd_cross(yAxis, xAxisProjected))
+        let zAxis = simd_normalize(simd_cross(xAxisProjected, yAxis))
         let xAxis = simd_normalize(simd_cross(yAxis, zAxis))
 
         let origin = SIMD3<Float>(a0World.x, planeHeight, a0World.z)

--- a/LonelyPianistAVP/Models/Calibration/PianoCalibration.swift
+++ b/LonelyPianistAVP/Models/Calibration/PianoCalibration.swift
@@ -23,6 +23,10 @@ struct PianoCalibration: Codable, Equatable {
     let planeNormal: CodableVector3
     let planeHeight: Float
     let whiteKeyWidth: Float
+    /// In keyboard-local space (see `KeyboardFrame`), the calibrated A0/C8 points are interpreted as
+    /// the keyboard *front edge line* (z = 0). This offset tells us where the key-center line sits
+    /// along the local Z axis (typically ±keyDepth/2).
+    let frontEdgeToKeyCenterLocalZ: Float
     let generatedAt: Date
 
     init(
@@ -31,6 +35,7 @@ struct PianoCalibration: Codable, Equatable {
         planeNormal: SIMD3<Float> = SIMD3<Float>(0, 1, 0),
         planeHeight: Float,
         whiteKeyWidth: Float = 0.0235,
+        frontEdgeToKeyCenterLocalZ: Float = 0,
         generatedAt: Date = .now
     ) {
         self.a0 = CodableVector3(a0)
@@ -38,6 +43,7 @@ struct PianoCalibration: Codable, Equatable {
         self.planeNormal = CodableVector3(planeNormal)
         self.planeHeight = planeHeight
         self.whiteKeyWidth = whiteKeyWidth
+        self.frontEdgeToKeyCenterLocalZ = frontEdgeToKeyCenterLocalZ
         self.generatedAt = generatedAt
     }
 }

--- a/LonelyPianistAVP/README.md
+++ b/LonelyPianistAVP/README.md
@@ -18,13 +18,17 @@
 
 ## 关键限制
 
-- 当前只接受外部准备好的 `MusicXML`
 - 当前 MVP 依赖 **A0 / C8 两点校准**
+- App 启动时会尝试自动导入内置 seed（Opus 的 MusicXML）以便快速进入 Step 3；你也可以在 Step 2 导入外部 `MusicXML`。
 - `SalC5Light2.sf2` 默认需要放在：
 
 ```text
 LonelyPianistAVP/Resources/Audio/SoundFonts/SalC5Light2.sf2
 ```
+
+## 调试
+
+- 练习设置中可以开启 **调试：显示键盘坐标轴（X/Y/Z）**，用于确认键盘 frame 的原点与轴向。
 
 ## 运行说明
 

--- a/LonelyPianistAVP/Services/PianoKeyGeometryService.swift
+++ b/LonelyPianistAVP/Services/PianoKeyGeometryService.swift
@@ -17,24 +17,26 @@ struct PianoKeyGeometryService: PianoKeyGeometryServiceProtocol {
         let a0World = calibration.a0.simdValue
         let c8World = calibration.c8.simdValue
 
-        // P1 assumes the keyboard is perfectly horizontal. Use the horizontal projection to avoid
-        // y-noise in tracked anchors from skewing key spacing.
-        let delta = SIMD3<Float>(c8World.x - a0World.x, 0, c8World.z - a0World.z)
-        let totalDistance = simd_length(delta)
-        guard totalDistance > 0.0001 else {
+        let planeY = calibration.planeHeight
+        guard let frame = KeyboardFrame(a0World: a0World, c8World: c8World, planeHeight: planeY) else {
             return []
         }
-        let axis = delta / totalDistance
+
+        // P1 assumes the keyboard is perfectly horizontal. The keyboard frame's +X is already
+        // computed from the horizontal projection of (A0 -> C8).
+        let totalDistance = simd_length(SIMD3<Float>(c8World.x - a0World.x, 0, c8World.z - a0World.z))
+        guard totalDistance > 0.0001 else { return [] }
         let keySpacing = totalDistance / Float(max(1, keyCount - 1))
 
         let depth: Float = Self.keyDepthMeters
         let height: Float = Self.keyHeightMeters
-        let planeY = calibration.planeHeight
-        let a0 = SIMD3<Float>(a0World.x, planeY, a0World.z)
+        let z = calibration.frontEdgeToKeyCenterLocalZ
 
         return (0 ..< keyCount).map { index in
             let midi = firstMIDINote + index
-            let center = a0 + axis * (Float(index) * keySpacing)
+            let centerLocal = SIMD4<Float>(Float(index) * keySpacing, 0, z, 1)
+            let centerWorld4 = simd_mul(frame.worldFromKeyboard, centerLocal)
+            let center = SIMD3<Float>(centerWorld4.x, centerWorld4.y, centerWorld4.z)
             let width = max(0.01, calibration.whiteKeyWidth)
             return PianoKeyRegion(
                 midiNote: midi,

--- a/LonelyPianistAVP/Services/PianoKeyGeometryService.swift
+++ b/LonelyPianistAVP/Services/PianoKeyGeometryService.swift
@@ -9,6 +9,10 @@ struct PianoKeyGeometryService: PianoKeyGeometryServiceProtocol {
     private let keyCount = 88
     private let firstMIDINote = 21 // A0
 
+    // Approximate physical dimensions used for hit regions and AR highlights.
+    static let keyDepthMeters: Float = 0.14
+    static let keyHeightMeters: Float = 0.03
+
     func generateKeyRegions(from calibration: PianoCalibration) -> [PianoKeyRegion] {
         let a0World = calibration.a0.simdValue
         let c8World = calibration.c8.simdValue
@@ -23,8 +27,8 @@ struct PianoKeyGeometryService: PianoKeyGeometryServiceProtocol {
         let axis = delta / totalDistance
         let keySpacing = totalDistance / Float(max(1, keyCount - 1))
 
-        let depth: Float = 0.14
-        let height: Float = 0.03
+        let depth: Float = Self.keyDepthMeters
+        let height: Float = Self.keyHeightMeters
         let planeY = calibration.planeHeight
         let a0 = SIMD3<Float>(a0World.x, planeY, a0World.z)
 

--- a/LonelyPianistAVP/Services/RealityKit/KeyboardAxesDebugOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/KeyboardAxesDebugOverlayController.swift
@@ -1,5 +1,6 @@
 import RealityKit
 import SwiftUI
+import UIKit
 
 @MainActor
 final class KeyboardAxesDebugOverlayController {
@@ -43,6 +44,9 @@ final class KeyboardAxesDebugOverlayController {
         let xLen: Float = 0.30
         let yLen: Float = 0.18
         let zLen: Float = 0.20
+        let labelFontSize: CGFloat = 0.08
+        let labelExtrusion: Float = 0.004
+        let labelOffset: Float = 0.02
 
         let xAxis = ModelEntity(
             mesh: .generateBox(size: SIMD3<Float>(xLen, thickness, thickness)),
@@ -65,5 +69,31 @@ final class KeyboardAxesDebugOverlayController {
         axesRootEntity.addChild(xAxis)
         axesRootEntity.addChild(yAxis)
         axesRootEntity.addChild(zAxis)
+
+        // Axis labels (X/Y/Z) near the positive ends.
+        let xLabel = axisLabelEntity(text: "X", color: .systemRed, fontSize: labelFontSize, extrusion: labelExtrusion)
+        xLabel.position = SIMD3<Float>(xLen + labelOffset, 0, 0)
+        axesRootEntity.addChild(xLabel)
+
+        let yLabel = axisLabelEntity(text: "Y", color: .systemGreen, fontSize: labelFontSize, extrusion: labelExtrusion)
+        yLabel.position = SIMD3<Float>(0, yLen + labelOffset, 0)
+        axesRootEntity.addChild(yLabel)
+
+        let zLabel = axisLabelEntity(text: "Z", color: .systemBlue, fontSize: labelFontSize, extrusion: labelExtrusion)
+        zLabel.position = SIMD3<Float>(0, 0, zLen + labelOffset)
+        axesRootEntity.addChild(zLabel)
+    }
+
+    private func axisLabelEntity(text: String, color: UIColor, fontSize: CGFloat, extrusion: Float) -> ModelEntity {
+        let font = UIFont.systemFont(ofSize: fontSize, weight: .semibold)
+        let mesh = MeshResource.generateText(
+            text,
+            extrusionDepth: extrusion,
+            font: font,
+            containerFrame: .zero,
+            alignment: .center,
+            lineBreakMode: .byClipping
+        )
+        return ModelEntity(mesh: mesh, materials: [SimpleMaterial(color: color, isMetallic: false)])
     }
 }

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -79,7 +79,7 @@ final class PianoGuideOverlayController {
                 activeMarkersByMIDINote[midiNote] = marker
                 keyboardRootEntity.addChild(marker)
             }
-            marker.position = SIMD3<Float>(centerLocal.x, centerLocal.y + region.size.y * 0.6, centerLocal.z)
+            marker.position = SIMD3<Float>(centerLocal.x, centerLocal.y, centerLocal.z)
         }
     }
 

--- a/LonelyPianistAVP/ViewModels/ARGuideViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuideViewModel.swift
@@ -16,6 +16,7 @@ final class ARGuideViewModel {
         case anchorMissing(id: UUID)
         case anchorNotTracked(id: UUID, waitedSeconds: Int)
         case anchorsTooClose(distanceMeters: Float)
+        case devicePoseUnavailable(waitedSeconds: Int)
         case immersiveOpenFailed(message: String)
 
         var message: String {
@@ -36,6 +37,8 @@ final class ARGuideViewModel {
                     "无法定位：锚点存在但尚未追踪（id=\(id.uuidString)，已等待 \(waitedSeconds) 秒）。"
                 case let .anchorsTooClose(distanceMeters):
                     "校准数据异常：A0 与 C8 距离过近（\(String(format: "%.3f", distanceMeters))m）。请返回 Step 1 重新校准。"
+                case let .devicePoseUnavailable(waitedSeconds):
+                    "无法定位：设备位姿尚不可用（已等待 \(waitedSeconds) 秒）。"
                 case let .immersiveOpenFailed(message):
                     message
             }
@@ -511,6 +514,9 @@ final class ARGuideViewModel {
                         dismissImmersiveSpace: dismissImmersiveSpace
                     )
                     return
+
+                case .devicePoseUnavailable:
+                    lastRecoverableResolution = .devicePoseUnavailable
             }
 
             if elapsed >= Double(practiceLocalizationTimeoutSeconds) {
@@ -546,6 +552,8 @@ final class ARGuideViewModel {
                 )
             case let .anchorsTooClose(distanceMeters):
                 return .anchorsTooClose(distanceMeters: distanceMeters)
+            case .devicePoseUnavailable:
+                return .devicePoseUnavailable(waitedSeconds: practiceLocalizationTimeoutSeconds)
             case .resolved:
                 return .providerNotRunning(state: currentProviderStateSummary())
             case .missingStoredCalibration:


### PR DESCRIPTION
## Summary
- 统一校准与练习阶段的键盘坐标系语义，明确 A0/C8 代表前沿线
- 修正 `KeyboardFrame` 的轴向推导，避免键盘高亮整体偏到 A0 左侧
- 让 AR 高亮方块贴合键盘平面，并补充坐标轴调试标注与文档说明
- 补齐相关单测与 ARKit 授权需求检查，更新 deepwiki、README 和 AGENTS

## Testing
- 已补充并更新 `KeyboardFrame`、`PianoKeyGeometryService`、`PressDetectionService`、`PracticeSessionViewModel` 等相关测试
- 已完成本地 `xcodebuild` 构建验证，AVP 目标通过