### PR TITLE
SwiftUI performance audit pass

### DIFF
--- a/LonelyPianist/Views/Recording/PianoRollView.swift
+++ b/LonelyPianist/Views/Recording/PianoRollView.swift
@@ -11,13 +11,15 @@ struct PianoRollView: View {
 
     var body: some View {
         if let take {
+            let noteRange = noteRange(for: take)
+
             ScrollView([.horizontal, .vertical]) {
                 Canvas { context, size in
-                    drawGrid(in: &context, size: size, take: take)
-                    drawNotes(in: &context, take: take)
+                    drawGrid(in: &context, size: size, take: take, noteRange: noteRange)
+                    drawNotes(in: &context, take: take, noteRange: noteRange)
                     drawPlayhead(in: &context, size: size, take: take)
                 }
-                .frame(width: canvasWidth(for: take), height: canvasHeight(for: take))
+                .frame(width: canvasWidth(for: take), height: canvasHeight(for: noteRange))
             }
             .background(Color(nsColor: .textBackgroundColor))
         } else {
@@ -52,8 +54,12 @@ struct PianoRollView: View {
         )
     }
 
-    private func drawGrid(in context: inout GraphicsContext, size: CGSize, take: RecordingTake) {
-        let range = noteRange(for: take)
+    private func drawGrid(
+        in context: inout GraphicsContext,
+        size: CGSize,
+        take: RecordingTake,
+        noteRange: ClosedRange<Int>
+    ) {
         let background = Path(CGRect(origin: .zero, size: size))
         context.fill(background, with: .color(Color(nsColor: .textBackgroundColor)))
 
@@ -65,8 +71,8 @@ struct PianoRollView: View {
             context.stroke(line, with: .color(.gray.opacity(second % 4 == 0 ? 0.35 : 0.18)))
         }
 
-        for note in range.lowerBound ... range.upperBound {
-            let y = yPosition(for: note, range: range)
+        for note in noteRange {
+            let y = yPosition(for: note, range: noteRange)
             var line = Path()
             line.move(to: CGPoint(x: leftInset, y: y))
             line.addLine(to: CGPoint(x: size.width - 8, y: y))
@@ -83,10 +89,9 @@ struct PianoRollView: View {
         }
     }
 
-    private func drawNotes(in context: inout GraphicsContext, take: RecordingTake) {
-        let range = noteRange(for: take)
+    private func drawNotes(in context: inout GraphicsContext, take: RecordingTake, noteRange: ClosedRange<Int>) {
         for recordedNote in take.notes {
-            let y = yPosition(for: recordedNote.note, range: range) + 1
+            let y = yPosition(for: recordedNote.note, range: noteRange) + 1
             let x = leftInset + (CGFloat(recordedNote.startOffsetSec) * secondWidth)
             let width = max(2, CGFloat(recordedNote.durationSec) * secondWidth)
             let rect = CGRect(x: x, y: y, width: width, height: rowHeight - 2)
@@ -97,9 +102,15 @@ struct PianoRollView: View {
     }
 
     private func noteRange(for take: RecordingTake) -> ClosedRange<Int> {
-        guard let minNote = take.notes.map(\.note).min(),
-              let maxNote = take.notes.map(\.note).max()
-        else {
+        var minNote: Int?
+        var maxNote: Int?
+
+        for recordedNote in take.notes {
+            minNote = min(minNote ?? recordedNote.note, recordedNote.note)
+            maxNote = max(maxNote ?? recordedNote.note, recordedNote.note)
+        }
+
+        guard let minNote, let maxNote else {
             return 48 ... 72
         }
 
@@ -112,9 +123,8 @@ struct PianoRollView: View {
         max(860, leftInset + (CGFloat(max(1, take.durationSec)) * secondWidth) + 40)
     }
 
-    private func canvasHeight(for take: RecordingTake) -> CGFloat {
-        let range = noteRange(for: take)
-        let rows = CGFloat((range.upperBound - range.lowerBound) + 1)
+    private func canvasHeight(for noteRange: ClosedRange<Int>) -> CGFloat {
+        let rows = CGFloat((noteRange.upperBound - noteRange.lowerBound) + 1)
         return max(420, topInset + (rows * rowHeight) + 28)
     }
 

--- a/LonelyPianist/Views/Runtime/RecentEventSectionView.swift
+++ b/LonelyPianist/Views/Runtime/RecentEventSectionView.swift
@@ -13,7 +13,7 @@ struct RecentEventSectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(viewModel.recentLogs.prefix(12))) { item in
+                    ForEach(viewModel.recentLogs.prefix(12)) { item in
                         HStack(alignment: .top, spacing: 8) {
                             Text(timeString(item.timestamp))
                                 .font(.caption2.monospacedDigit())
@@ -38,8 +38,11 @@ struct RecentEventSectionView: View {
     }
 
     private func timeString(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        return formatter.string(from: date)
+        date.formatted(Self.eventTimeStyle)
     }
+
+    private static let eventTimeStyle = Date.FormatStyle()
+        .hour(.twoDigits(amPM: .omitted))
+        .minute(.twoDigits)
+        .second(.twoDigits)
 }

--- a/LonelyPianistAVP/Views/PianoKeyboard88View.swift
+++ b/LonelyPianistAVP/Views/PianoKeyboard88View.swift
@@ -6,58 +6,29 @@ struct PianoKeyboard88View: View {
     let highlightedMIDINotes: Set<Int>
     let fingeringByMIDINote: [Int: String]
 
-    private let playableRange = 21 ... 108
-    private let blackPitchClasses: Set<Int> = [1, 3, 6, 8, 10]
-
     init(highlightedMIDINotes: Set<Int>, fingeringByMIDINote: [Int: String] = [:]) {
         self.highlightedMIDINotes = highlightedMIDINotes
         self.fingeringByMIDINote = fingeringByMIDINote
     }
 
-    private var highlightedInRange: Set<Int> {
-        Set(highlightedMIDINotes.filter { playableRange.contains($0) })
-    }
-
-    private var whiteKeys: [WhiteKey] {
-        var keys: [WhiteKey] = []
-        var whiteIndex = 0
-
-        for midiNote in playableRange {
-            guard isBlackKey(midiNote) == false else { continue }
-            keys.append(WhiteKey(midiNote: midiNote, whiteIndex: whiteIndex))
-            whiteIndex += 1
-        }
-
-        return keys
-    }
-
-    private var blackKeys: [BlackKey] {
-        let whiteIndexByMIDINote = Dictionary(uniqueKeysWithValues: whiteKeys.map { ($0.midiNote, $0.whiteIndex) })
-
-        return playableRange.compactMap { midiNote in
-            guard isBlackKey(midiNote) else { return nil }
-            guard let leftWhiteIndex = whiteIndexByMIDINote[midiNote - 1] else { return nil }
-            return BlackKey(midiNote: midiNote, leftWhiteIndex: leftWhiteIndex)
-        }
-    }
-
     var body: some View {
         GeometryReader { proxy in
-            let whiteKeyWidth = proxy.size.width / CGFloat(max(1, whiteKeys.count))
+            let whiteKeyWidth = proxy.size.width / CGFloat(max(1, Self.whiteKeys.count))
             let whiteKeyHeight = proxy.size.height
             let blackKeyWidth = whiteKeyWidth * 0.62
             let blackKeyHeight = whiteKeyHeight * 0.62
 
             ZStack(alignment: .topLeading) {
-                ForEach(whiteKeys) { key in
+                ForEach(Self.whiteKeys) { key in
+                    let isHighlighted = isHighlighted(key.midiNote)
                     Rectangle()
-                        .fill(highlightedInRange.contains(key.midiNote) ? .yellow.opacity(0.48) : .white)
+                        .fill(isHighlighted ? .yellow.opacity(0.48) : .white)
                         .overlay {
                             Rectangle()
                                 .stroke(.black.opacity(0.22), lineWidth: 0.6)
                         }
                         .overlay(alignment: .bottom) {
-                            if highlightedInRange.contains(key.midiNote),
+                            if isHighlighted,
                                let fingering = fingeringByMIDINote[key.midiNote]
                             {
                                 Text(fingering)
@@ -70,15 +41,16 @@ struct PianoKeyboard88View: View {
                         .offset(x: CGFloat(key.whiteIndex) * whiteKeyWidth)
                 }
 
-                ForEach(blackKeys) { key in
+                ForEach(Self.blackKeys) { key in
+                    let isHighlighted = isHighlighted(key.midiNote)
                     Rectangle()
-                        .fill(highlightedInRange.contains(key.midiNote) ? .orange.opacity(0.95) : .black.opacity(0.88))
+                        .fill(isHighlighted ? .orange.opacity(0.95) : .black.opacity(0.88))
                         .overlay {
                             Rectangle()
                                 .stroke(.white.opacity(0.28), lineWidth: 0.5)
                         }
                         .overlay(alignment: .bottom) {
-                            if highlightedInRange.contains(key.midiNote),
+                            if isHighlighted,
                                let fingering = fingeringByMIDINote[key.midiNote]
                             {
                                 Text(fingering)
@@ -99,7 +71,37 @@ struct PianoKeyboard88View: View {
         .accessibilityLabel("88 键钢琴")
     }
 
-    private func isBlackKey(_ midiNote: Int) -> Bool {
+    private func isHighlighted(_ midiNote: Int) -> Bool {
+        highlightedMIDINotes.contains(midiNote)
+    }
+
+    private static let playableRange = 21 ... 108
+    private static let blackPitchClasses: Set<Int> = [1, 3, 6, 8, 10]
+
+    private static let whiteKeys: [WhiteKey] = {
+        var keys: [WhiteKey] = []
+        var whiteIndex = 0
+
+        for midiNote in playableRange {
+            guard isBlackKey(midiNote) == false else { continue }
+            keys.append(WhiteKey(midiNote: midiNote, whiteIndex: whiteIndex))
+            whiteIndex += 1
+        }
+
+        return keys
+    }()
+
+    private static let blackKeys: [BlackKey] = {
+        let whiteIndexByMIDINote = Dictionary(uniqueKeysWithValues: whiteKeys.map { ($0.midiNote, $0.whiteIndex) })
+
+        return playableRange.compactMap { midiNote in
+            guard isBlackKey(midiNote) else { return nil }
+            guard let leftWhiteIndex = whiteIndexByMIDINote[midiNote - 1] else { return nil }
+            return BlackKey(midiNote: midiNote, leftWhiteIndex: leftWhiteIndex)
+        }
+    }()
+
+    private static func isBlackKey(_ midiNote: Int) -> Bool {
         blackPitchClasses.contains(midiNote % 12)
     }
 }


### PR DESCRIPTION
## Summary
- Avoid per-row formatter allocation in Recent Events rendering.
- Cache the static 88-key visionOS piano layout instead of rebuilding white/black key arrays every body pass.
- Avoid repeated note-range scans in PianoRollView drawing by deriving the range once per render pass and passing it through grid/note drawing.

## Audit findings addressed
1. Runtime panel event log created a DateFormatter during row rendering.
2. PianoKeyboard88View rebuilt fixed keyboard geometry on every view update.
3. PianoRollView recalculated note range multiple times while drawing the same take.

## Testing
- Not run; code review / low-risk SwiftUI rendering optimization pass only.
- Recommended follow-up: profile playback in Instruments SwiftUI Timeline + Time Profiler before/after while playing a large imported MIDI take.