### PR TITLE
Add PR-only split Xcode test workflow

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -43,7 +43,7 @@ jobs:
     name: macOS tests
     needs: changes
     if: needs.changes.outputs.macos == 'true'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
     name: AVP tests
     needs: changes
     if: needs.changes.outputs.avp == 'true'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,86 @@
+name: PR Tests
+
+on:
+  pull_request:
+    paths:
+      - "LonelyPianist/**"
+      - "LonelyPianistTests/**"
+      - "LonelyPianistAVP/**"
+      - "LonelyPianistAVPTests/**"
+      - "LonelyPianist.xcodeproj/**"
+      - "Packages/RealityKitContent/**"
+      - ".github/workflows/pr-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed targets
+    runs-on: ubuntu-latest
+    outputs:
+      macos: ${{ steps.filter.outputs.macos }}
+      avp: ${{ steps.filter.outputs.avp }}
+    steps:
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            macos:
+              - 'LonelyPianist/**'
+              - 'LonelyPianistTests/**'
+              - 'LonelyPianist.xcodeproj/**'
+              - '.github/workflows/pr-tests.yml'
+            avp:
+              - 'LonelyPianistAVP/**'
+              - 'LonelyPianistAVPTests/**'
+              - 'Packages/RealityKitContent/**'
+              - 'LonelyPianist.xcodeproj/**'
+              - '.github/workflows/pr-tests.yml'
+
+  macos-tests:
+    name: macOS tests
+    needs: changes
+    if: needs.changes.outputs.macos == 'true'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: List schemes
+        run: xcodebuild -list -project LonelyPianist.xcodeproj
+
+      - name: Run macOS tests
+        run: |
+          xcodebuild test \
+            -project LonelyPianist.xcodeproj \
+            -scheme LonelyPianist \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO
+
+  avp-tests:
+    name: AVP tests
+    needs: changes
+    if: needs.changes.outputs.avp == 'true'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: List schemes
+        run: xcodebuild -list -project LonelyPianist.xcodeproj
+
+      - name: Run AVP tests
+        run: |
+          xcodebuild test \
+            -project LonelyPianist.xcodeproj \
+            -scheme LonelyPianistAVP \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            CODE_SIGNING_ALLOWED=NO

--- a/LonelyPianist/Services/MIDI/CoreMIDIInputService.swift
+++ b/LonelyPianist/Services/MIDI/CoreMIDIInputService.swift
@@ -104,7 +104,7 @@ final class CoreMIDIInputService: MIDIInputServiceProtocol {
         onSourceNamesChange?(sourceNames)
 
         onConnectionStateChange?(.connected(sourceCount: connectedSources.count))
-        logger.info("MIDI connected source count: \(connectedSources.count, privacy: .public)")
+        logger.info("MIDI connected source count: \(self.connectedSources.count, privacy: .public)")
     }
 
     private func createClientIfNeeded() throws {


### PR DESCRIPTION
## Summary
- Add a PR-only test workflow that runs only on `pull_request` events.
- Split macOS and AVP tests into separate jobs based on changed paths.
- Run macOS tests when `LonelyPianist/`, `LonelyPianistTests/`, or project files change.
- Run AVP tests when `LonelyPianistAVP/`, `LonelyPianistAVPTests/`, `Packages/RealityKitContent/`, or project files change.

## Notes
- This does not change the manual-only Swift Quality workflow.
- macOS uses the shared `LonelyPianist` scheme.
- AVP currently assumes a `LonelyPianistAVP` scheme is available; if it is not shared, the workflow will fail at scheme discovery/test time and the scheme should be shared in Xcode.

## Testing
- Not run locally; this is a GitHub Actions workflow addition.