### PR TITLE
feat: add rectangular volumetric AR key beams

### DIFF
--- a/.github/deepwiki/GENERATION.md
+++ b/.github/deepwiki/GENERATION.md
@@ -3,25 +3,25 @@
 ## Run info
 | Item | Value |
 | --- | --- |
-| Commit hash | 3cb80c0eaa078e9133c33b680e4b8f3dad4af5f8 |
-| Branch name | main |
-| Generated at | 2026-04-25T04:30:00+09:00 |
+| Commit hash | rectangular-ar-light-beams branch work, latest implementation commit pending PR CI |
+| Branch name | rectangular-ar-light-beams |
+| Generated at | 2026-04-25T00:00:00+09:00 |
 | Output language | Chinese |
-| Generation mode | Incremental update via `deepwiki` skill |
+| Generation mode | Incremental update for rectangular AR light beams |
 
 ## Generated / updated pages
-- `INDEX.md`
 - `GENERATION.md`
-- `overview.md`
-- `architecture.md`
 - `data-flow.md`
 - `configuration.md`
-- `testing.md`
-- `workflow.md`
-- `troubleshooting.md`
 - `modules/lonelypianist-avp-practice.md`
 
 ## Existing pages retained
+- `INDEX.md`
+- `overview.md`
+- `architecture.md`
+- `testing.md`
+- `workflow.md`
+- `troubleshooting.md`
 - `business-context.md`
 - `dependencies.md`
 - `storage.md`
@@ -45,32 +45,29 @@
 - None. `.github/deepwiki/assets/` remains reserved for future diagrams or screenshots.
 
 ## Evidence used
-- Top-level `README.md` product framing and repository layout.
-- `.github/workflows/pr-tests.yml` for PR-only macOS / AVP split Xcode tests.
-- `.github/workflows/swift-quality.yml` for manual-only SwiftFormat / SwiftLint autocorrect.
-- `LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift` for light-beam AR guide implementation.
+- `LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift` for rectangular volumetric beam implementation.
+- `LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift` for pure geometry coverage.
+- `LonelyPianistAVP/Services/PianoKeyGeometryService.swift` and `PianoKeyRegion` model for key region shape assumptions.
 - Existing deepwiki pages and module boundaries.
-- Recent PR #45 result: PR-only split Xcode workflow merged, with macOS and AVP tests validated through GitHub Actions.
 
 ## Key updates in this generation
 | Area | Update |
 | --- | --- |
-| CI | Replaced outdated “no CI” statements with current PR Tests / Swift Quality workflow facts. |
-| Testing | Documented `macos-26`, Xcode 26.2 / Swift 6.2 requirements, macOS tests, AVP simulator tests, and `build-for-testing` vs `test`. |
-| AVP practice | Replaced old key-highlight wording with RealityKit cylinder light-beam guide details. |
-| Configuration | Added PR path filters, workflow permissions, SwiftFormat/SwiftLint config, and AVP simulator destination notes. |
-| Troubleshooting | Added package graph, simulator destination, AVP runtime latency, Swift Quality, and light-beam diagnostics. |
-| Index | Added `ci-first` reading path and current automation facts. |
+| AVP practice | Replaced RealityKit cylinder light-beam wording with rectangular volumetric beam details. |
+| AR guide geometry | Documented key-top placement, rectangular footprint, black-key overlay scaling, three body segments, base glow, and deterministic dust particles. |
+| Configuration | Replaced cylinder radius/alpha settings with rectangular beam parameters and misconfiguration notes. |
+| Data flow | Updated the spatial prompt flow from single `ModelEntity` cylinder to compound `KeyBeamMarker`. |
 
 ## Current Coverage Gaps
 - Python smoke tests are not yet part of GitHub Actions.
 - There is no unified release workflow.
 - There is no full macOS -> Python -> AVP end-to-end automated test.
-- AVP simulator tests are validated in Actions, but real Vision Pro hand tracking and light-beam comfort still require manual device testing.
+- AVP simulator tests can verify build and logic, but real Vision Pro hand tracking, optical comfort, and perceived Tyndall-style light scattering still require manual device testing.
 
 ## Validation checklist
-- [x] Core pages updated where CI / testing / AVP guide facts changed.
-- [x] `INDEX.md` updated with CI-first path and current automation facts.
-- [x] `GENERATION.md` updated with branch, commit, language, page list, and gaps.
 - [x] AVP light-beam implementation documented in module page.
-- [x] Deprecated “no CI” and “AVP scheme not validated” statements removed from updated pages.
+- [x] Data flow updated for rectangular compound beams.
+- [x] Configuration updated for rectangular beam parameters.
+- [x] Deprecated cylinder/radius wording removed from updated pages.
+- [x] Geometry helper tests added for footprint, key-top placement, segment stacking/fade, and deterministic dust offsets.
+- [ ] PR CI pending after pull request creation.

--- a/.github/deepwiki/configuration.md
+++ b/.github/deepwiki/configuration.md
@@ -20,8 +20,11 @@
 | Press cooldown | `0.15s` | 手部按键去抖 |
 | Chord window | `0.6s` | 和弦累积 |
 | Practice note tolerance | `±1` 半音 | 练习匹配 |
-| Light beam height | `0.22` meter-ish RealityKit local units | 当前 step 的空间光柱高度 |
-| Light beam alpha | `0.42` | 光柱透明度 |
+| Rectangular beam height | `0.22` meter-ish RealityKit local units | 当前 step 的矩形体积光柱高度 |
+| Rectangular beam base offset | `0.006` | 光柱从琴键上表面向上偏移，避免穿进 key region |
+| Rectangular beam base glow height | `0.004` | 琴键表面发光薄片高度 |
+| Rectangular beam segments | `3` | 底部/中部/顶部渐隐段数 |
+| Rectangular beam dust particles | `8` per note | 稳定微粒数量，模拟丁达尔感 |
 
 ## 构建与工程配置
 | 项目 | 位置 | 说明 |
@@ -77,11 +80,15 @@
 | `macos-latest` 用于 Xcode tests | Swift tools 6.2 package graph 可能失败 | PR Tests 使用 `macos-26` |
 | AVP test destination 变更 | `xcodebuild` 找不到 Apple Vision Pro simulator | 先跑 `xcodebuild -showdestinations` 再调整 destination |
 | Swift Quality 在 PR 中自动触发 | workflow 可能自改 PR 分支并循环 | 当前只保留手动触发 |
+| 矩形光柱太亮或遮挡琴键 | 真机中可能像玻璃块或影响读谱 | 调低 segment alpha、base glow alpha 或 beam height |
+| 矩形光柱和琴键表面错位 | 视觉提示悬空或穿进琴键 | 检查 `PianoGuideBeamGeometry.rootLocalPosition`、`PianoKeyRegion.center/size` 和 `keyboardFrame.keyboardFromWorld` |
 
 ## Coverage Gaps
 - Python 依赖没有 lockfile；环境变量也没有统一 `.env.example`。
 - Python smoke tests 尚未进入 GitHub Actions。
 - AVP simulator tests 已验证可跑，但耗时高于 macOS tests；若后续不稳定，可拆为 `build-for-testing` 和手动完整 test。
+- 矩形体积光柱的透明度、丁达尔感和视觉舒适度仍需 Vision Pro 真机调参。
 
 ## 更新记录（Update Notes）
 - 2026-04-25: 更新 PR-only split tests、manual-only Swift Quality、`macos-26`、Swift tools 6.2 和 AVP light beam 参数。
+- 2026-04-25: 将 AVP light beam 配置从 cylinder radius/alpha 更新为 rectangular volumetric beam 参数。

--- a/.github/deepwiki/data-flow.md
+++ b/.github/deepwiki/data-flow.md
@@ -8,7 +8,7 @@
 | Dialogue | 静默触发 | DialogueManager -> WS -> inference | AI 回放 + take |
 | AVP seed | App 启动 | SongLibrarySeeder | 默认谱面和音频 |
 | AVP import | fileImporter URLs | SongFileStore + IndexStore | `SongLibrary/index.json` |
-| AVP practice | 校准 + 曲库 + tracking | ARGuideViewModel + PracticeSessionViewModel + PianoGuideOverlayController | 光柱引导、反馈和步骤推进 |
+| AVP practice | 校准 + 曲库 + tracking | ARGuideViewModel + PracticeSessionViewModel + PianoGuideOverlayController | 矩形体积光柱引导、反馈和步骤推进 |
 | PR validation | Pull request paths | paths-filter -> xcodebuild jobs | macOS / AVP tests |
 | Swift quality | 手动 workflow_dispatch | SwiftFormat + SwiftLint | 格式化 commit 或 lint 结果 |
 
@@ -38,7 +38,7 @@ sequenceDiagram
 | Step 2 选曲 | MusicXML / mp3 / m4a | `SongLibraryViewModel` | `SongLibraryIndex` |
 | MusicXML 处理 | score XML | `MusicXMLParser`, `PracticeStepBuilder` | `PracticeStep[]` + timelines |
 | Step 3 练习 | finger tips + steps | `ARGuideViewModel`, `PracticeSessionViewModel` | 匹配、反馈、autoplay |
-| 空间提示 | `PracticeStep.notes`, key regions, feedback state | `PianoGuideOverlayController` | RealityKit cylinder light beams |
+| 空间提示 | `PracticeStep.notes`, key regions, feedback state | `PianoGuideOverlayController`, `PianoGuideBeamGeometry` | RealityKit rectangular volumetric beams |
 
 ## AVP 练习内部
 | 子流 | 说明 | 关键状态 |
@@ -46,18 +46,20 @@ sequenceDiagram
 | 定位 | 恢复世界锚点并生成 calibration | `PracticeLocalizationState` |
 | 按键检测 | 指尖落点映射到 key regions | `pressedNotes` |
 | 匹配 | 当前 step 的和弦/音符匹配 | `VisualFeedbackState` |
-| 光柱提示 | 当前 step 的 MIDI notes 映射到 keyboard-local center | `activeMarkersByMIDINote` |
+| 矩形光柱提示 | 当前 step 的 MIDI notes 映射到 keyboard-local key-top 和 rectangular footprint | `activeMarkersByMIDINote` |
 | 自动演奏 | 根据 note spans / pedal / fermata 推进 | `autoplayState` |
 
 ```mermaid
 flowchart TD
   A[PracticeStep.notes] --> B[Build desired MIDI note set]
   C[PianoKeyRegion.center / size] --> D[Convert world center to keyboard-local]
-  B --> E[Create/update cylinder ModelEntity]
+  C --> I[Compute rectangular footprint and key top]
+  B --> E[Create/update compound KeyBeamMarker]
   D --> E
-  F[VisualFeedbackState] --> G[Select tint material]
+  I --> E
+  F[VisualFeedbackState] --> G[Select tint materials]
   G --> E
-  E --> H[RealityKit light beams above key centers]
+  E --> H[RealityKit rectangular beams above key footprints]
 ```
 
 ## Python 数据流
@@ -91,7 +93,7 @@ flowchart TD
 | DialogueManager | `idle -> listening -> thinking -> playing` |
 | PracticeLocalizationState | `idle -> blocked/openingImmersive/waitingForProviders/locating -> ready/failed` |
 | PracticeState | `idle -> ready -> guiding -> completed` |
-| PianoGuideOverlayController | no root -> attached root -> active markers -> cleared markers |
+| PianoGuideOverlayController | no root -> attached root -> active compound markers -> cleared markers |
 | SongAudio playback | `nil / playing / paused` 由当前条目驱动 |
 | PR Tests | path filter -> selected jobs -> xcodebuild test -> checks |
 
@@ -109,13 +111,15 @@ flowchart TD
 ## 调试抓手
 - macOS：`statusMessage`、`recentLogs`、`previewText`
 - AVP：`practiceLocalizationStatusText`、`calibrationStatusMessage`、`currentListeningEntryID`、`autoplayHighlightedMIDINotes`
-- RealityKit 光柱：`activeMarkersByMIDINote`、`PianoKeyRegion.center`、`keyboardFrame.keyboardFromWorld`
+- RealityKit 矩形光柱：`activeMarkersByMIDINote`、`PianoKeyRegion.center`、`PianoKeyRegion.size`、`PianoGuideBeamGeometry.beamFootprint(for:)`、`keyboardFrame.keyboardFromWorld`
 - Python：`/health`、`test_client.py`、`out/dialogue_debug/index.jsonl`
 - CI：Actions job logs、`xcodebuild -list`、`.xcresult` 路径、combined checks
 
 ## Coverage Gaps
 - 没有自动化 E2E 去验证 macOS -> Python -> AVP 三端全链路；现状仍需要多处单元测试和人工冒烟组合覆盖。
 - Python smoke tests 尚未纳入 PR workflow。
+- 矩形体积光柱的真实空间舒适度、透明度和丁达尔感仍需 Vision Pro 真机观察。
 
 ## 更新记录（Update Notes）
 - 2026-04-25: 增补 PR Tests / Swift Quality 数据流、AVP 光柱提示数据流和 simulator test 失败恢复路径。
+- 2026-04-25: 将 AVP guide 数据流从 cylinder marker 更新为 rectangular volumetric beam marker。

--- a/.github/deepwiki/modules/lonelypianist-avp-practice.md
+++ b/.github/deepwiki/modules/lonelypianist-avp-practice.md
@@ -1,7 +1,7 @@
 # AVP Practice
 
 ## 范围
-练习页覆盖 Step 3 的定位后练习体验：step 推进、按键匹配、视觉反馈、autoplay、pedal / fermata / timing，以及当前 step 的 RealityKit 光柱式琴键引导。
+练习页覆盖 Step 3 的定位后练习体验：step 推进、按键匹配、视觉反馈、autoplay、pedal / fermata / timing，以及当前 step 的 RealityKit 矩形体积光柱琴键引导。
 
 ## 关键对象
 | 对象 | 职责 | 修改风险 |
@@ -12,17 +12,27 @@
 | `SoundFontPracticeNoteAudioPlayer` | 练习音色播放 | 影响试听 / autoplay |
 | `PracticeMIDINoteOutputProtocol` | note on/off 输出 | 影响可替换输出后端 |
 | `PianoGuideOverlayController` | RealityKit 空间光柱提示 | 影响当前 step 的可见 AR 引导 |
+| `PianoGuideBeamGeometry` | 纯逻辑几何 helper：footprint、key-top placement、segments、dust offsets | 影响光柱外观和测试覆盖 |
 
 ## 光柱引导实现
-`PianoGuideOverlayController` 不再用贴在琴键上的高亮块，而是为当前 step 的 MIDI notes 创建半透明 cylinder 光柱。光柱挂在 `keyboardRootEntity` 下，并继承 `keyboardFrame.worldFromKeyboard` 的键盘姿态。
+`PianoGuideOverlayController` 不再使用圆柱 marker。当前实现为每个目标 MIDI note 创建一个 compound rectangular volumetric beam：
+
+- `root`：挂到 `keyboardRootEntity` 下，继承 `keyboardFrame.worldFromKeyboard`。
+- `bodySegments`：三段 `generateBox(size: 1)` 叠成矩形体积光柱，底部更亮，顶部更淡。
+- `baseGlow`：贴近琴键上表面的薄矩形 glow，让光束像从琴键升起。
+- `particles`：少量 deterministic sphere 粒子，模拟丁达尔效应中的空气微粒。
+
+光柱底面来自 `PianoKeyRegion.size`，但为了不影响 hit-testing，黑键视觉宽度/深度只在 overlay 层用 `PianoGuideBeamGeometry.isBlackKey(midiNote:)` 做缩放。
 
 | 参数 | 当前值 | 作用 |
 | --- | --- | --- |
-| `lightBeamHeight` | `0.22` | 光柱高度 |
-| `lightBeamBaseYOffset` | `0.006` | 从 key center 往上偏移的基准 |
-| `lightBeamRadiusScale` | `0.32` | 根据 key footprint 缩放光柱半径 |
-| `lightBeamMinimumRadius` | `0.006` | 防止窄键半径过小 |
-| `lightBeamAlpha` | `0.42` | 半透明材质 alpha |
+| `beamHeight` | `0.22` | 矩形光柱总高度 |
+| `beamBaseYOffset` | `0.006` | 从 key top 往上偏移，避免穿进琴键 |
+| `baseGlowHeight` | `0.004` | 底部发光薄片高度 |
+| `minimumBeamWidth` | `0.006` | 防止视觉宽度过小 |
+| `minimumBeamDepth` | `0.018` | 防止视觉深度过小 |
+| `bodySegmentCount` | `3` | 底部/中部/顶部三段渐隐 |
+| `dustParticleCount` | `8` | 每个目标键的稳定光尘数量 |
 
 ## 光柱数据流
 ```mermaid
@@ -32,11 +42,14 @@ flowchart TD
   D --> E[world center]
   E --> F[keyboardFrame.keyboardFromWorld]
   F --> G[keyboard-local center]
-  B --> H[create/update ModelEntity cylinder]
-  G --> H
-  I[VisualFeedbackState] --> J[tint material]
-  J --> H
-  H --> K[keyboardRootEntity]
+  G --> H[key top + beamBaseYOffset]
+  D --> I[PianoGuideBeamGeometry.beamFootprint]
+  B --> J[create/update KeyBeamMarker]
+  H --> J
+  I --> J
+  K[VisualFeedbackState] --> L[tint materials]
+  L --> J
+  J --> M[keyboardRootEntity]
 ```
 
 ## 行为
@@ -46,6 +59,7 @@ flowchart TD
 - `skip()` 可手动跳步。
 - 当前 step 的每个 MIDI note 会被映射到对应 `PianoKeyRegion.center`。
 - 光柱中心会从 world-space key region center 转换到 keyboard-local 坐标，使 marker 继承键盘 yaw。
+- 光柱 root 的 y 坐标从 `keyTopY = centerLocal.y + region.size.y * 0.5` 开始，再加 `beamBaseYOffset`。
 - 光柱材质颜色由 `VisualFeedbackState` 决定：none / correct / wrong 对应不同 tint。
 - `activeMarkersByMIDINote` 只保留当前 step 所需 marker；离开当前 step 的 marker 会被移除。
 
@@ -54,15 +68,15 @@ flowchart TD
 | --- | --- | --- |
 | `idle` | 尚未开始 | 无光柱 |
 | `ready` | 已准备好 | 等待当前 step |
-| `guiding(stepIndex:)` | 正在引导 | 当前 step notes 上方显示光柱 |
+| `guiding(stepIndex:)` | 正在引导 | 当前 step notes 上方显示矩形体积光柱 |
 | `completed` | 完成 | 清理或停止 step marker |
 
 ## 反馈颜色与生命周期
 | 事件 | `VisualFeedbackState` | 光柱处理 |
 | --- | --- | --- |
 | 等待输入 | `.none` | 使用默认提示色 |
-| 命中正确 | `.correct` | 更新全部 active marker 材质 |
-| 命中错误 | `.wrong` | 更新全部 active marker 材质 |
+| 命中正确 | `.correct` | 更新全部 active marker 的 segments / baseGlow / particles 材质 |
+| 命中错误 | `.wrong` | 更新全部 active marker 的 segments / baseGlow / particles 材质 |
 | step 改变 | 由 ViewModel 决定 | 删除旧 note marker，创建或更新新 note marker |
 | 离开练习 / 无 keyboardFrame | N/A | `clearMarkers()` |
 
@@ -75,6 +89,8 @@ flowchart TD
 - `activeMarkersByMIDINote`
 - `keyboardFrame.keyboardFromWorld`
 - `PianoKeyRegion.center` / `PianoKeyRegion.size`
+- `PianoGuideBeamGeometry.beamFootprint(for:)`
+- `PianoGuideBeamGeometry.rootLocalPosition(centerLocal:region:)`
 
 ## 调试开关
 - `debugKeyboardAxesOverlayEnabled`：显示键盘坐标轴（含 X/Y/Z 标注），便于确认 keyboard frame 是否正确对齐 A0/C8。
@@ -84,13 +100,15 @@ flowchart TD
 | --- | --- |
 | step matching / feedback | `PracticeSessionViewModelTests.swift`、`StepMatcherTests.swift` |
 | MusicXML 到 step | `MusicXML*TimelineTests.swift`、parser tests |
+| 光柱几何计算 | `PianoGuideBeamGeometryTests.swift` |
 | 光柱空间表现 | AVP simulator tests + Vision Pro 手工观察 |
 | keyboard frame / center 转换 | 开启 debug axes，并观察 A0/C8 和当前 step marker 是否对齐 |
 | autoplay 与视觉提示 | AVP practice tests + 手工播放一段 MusicXML |
 
 ## Coverage Gaps
-- 光柱的可见高度、透明度和空间感仍主要依赖 Vision Pro 手工体验；逻辑测试只能覆盖数据和状态流，不能完全证明视觉舒适度。
+- 光柱的可见高度、透明度、渐隐和空间舒适度仍主要依赖 Vision Pro 手工体验；逻辑测试只能覆盖 footprint、key-top placement、segments 和 deterministic particles。
 - 当前 PR Tests 可以跑 AVP simulator tests，但不替代真机手部追踪与空间感验证。
 
 ## 更新记录（Update Notes）
-- 2026-04-25: 将旧“按键高亮块”描述更新为当前 RealityKit cylinder 光柱实现，并补充参数、数据流和验证入口。
+- 2026-04-25: 将旧“按键高亮块”描述更新为 RealityKit cylinder 光柱实现，并补充参数、数据流和验证入口。
+- 2026-04-25: 将 cylinder 光柱更新为矩形体积光柱：三段渐隐 box、base glow、稳定 dust particles 和 key-top placement。

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -2,19 +2,130 @@ import Foundation
 import RealityKit
 import SwiftUI
 
+struct PianoGuideBeamGeometry {
+    struct BodySegmentDescriptor {
+        let scale: SIMD3<Float>
+        let position: SIMD3<Float>
+        let alpha: CGFloat
+    }
+
+    static let beamHeight: Float = 0.22
+    static let beamBaseYOffset: Float = 0.006
+    static let baseGlowHeight: Float = 0.004
+    static let minimumBeamWidth: Float = 0.006
+    static let minimumBeamDepth: Float = 0.018
+    static let bodySegmentCount = 3
+    static let dustParticleCount = 8
+
+    private static let whiteKeyWidthScale: Float = 0.90
+    private static let whiteKeyDepthScale: Float = 0.88
+    private static let blackKeyWidthScale: Float = 0.58
+    private static let blackKeyDepthScale: Float = 0.56
+    private static let bodySegmentAlphas: [CGFloat] = [0.24, 0.13, 0.055]
+    private static let bodySegmentFootprintScales: [SIMD2<Float>] = [
+        SIMD2<Float>(1.04, 1.04),
+        SIMD2<Float>(0.92, 0.90),
+        SIMD2<Float>(0.74, 0.70)
+    ]
+
+    static func isBlackKey(midiNote: Int) -> Bool {
+        switch midiNote % 12 {
+            case 1, 3, 6, 8, 10:
+                return true
+            default:
+                return false
+        }
+    }
+
+    static func beamFootprint(for region: PianoKeyRegion) -> SIMD2<Float> {
+        let widthScale = isBlackKey(midiNote: region.midiNote) ? blackKeyWidthScale : whiteKeyWidthScale
+        let depthScale = isBlackKey(midiNote: region.midiNote) ? blackKeyDepthScale : whiteKeyDepthScale
+
+        return SIMD2<Float>(
+            max(region.size.x * widthScale, minimumBeamWidth),
+            max(region.size.z * depthScale, minimumBeamDepth)
+        )
+    }
+
+    static func rootLocalPosition(centerLocal: SIMD3<Float>, region: PianoKeyRegion) -> SIMD3<Float> {
+        let keyTopY = centerLocal.y + region.size.y * 0.5
+        return SIMD3<Float>(centerLocal.x, keyTopY + beamBaseYOffset, centerLocal.z)
+    }
+
+    static func baseGlowScale(footprint: SIMD2<Float>) -> SIMD3<Float> {
+        SIMD3<Float>(footprint.x * 1.08, baseGlowHeight, footprint.y * 1.08)
+    }
+
+    static func baseGlowPosition() -> SIMD3<Float> {
+        SIMD3<Float>(0, baseGlowHeight * 0.5, 0)
+    }
+
+    static func bodySegmentDescriptors(footprint: SIMD2<Float>) -> [BodySegmentDescriptor] {
+        let segmentHeight = beamHeight / Float(bodySegmentCount)
+
+        return (0 ..< bodySegmentCount).map { index in
+            let footprintScale = bodySegmentFootprintScales[index]
+            let scale = SIMD3<Float>(
+                footprint.x * footprintScale.x,
+                segmentHeight,
+                footprint.y * footprintScale.y
+            )
+            let position = SIMD3<Float>(
+                0,
+                baseGlowHeight + segmentHeight * (Float(index) + 0.5),
+                0
+            )
+
+            return BodySegmentDescriptor(
+                scale: scale,
+                position: position,
+                alpha: bodySegmentAlphas[index]
+            )
+        }
+    }
+
+    static func dustParticleOffsets(for midiNote: Int) -> [SIMD3<Float>] {
+        (0 ..< dustParticleCount).map { index in
+            let seed = Double(midiNote * 31 + index * 17)
+            let x = (unitNoise(seed * 12.9898) - 0.5) * 0.76
+            let y = 0.14 + unitNoise(seed * 78.233) * 0.72
+            let z = (unitNoise(seed * 37.719) - 0.5) * 0.76
+            return SIMD3<Float>(x, y, z)
+        }
+    }
+
+    static func dustParticlePosition(offset: SIMD3<Float>, footprint: SIMD2<Float>) -> SIMD3<Float> {
+        SIMD3<Float>(
+            offset.x * footprint.x,
+            baseGlowHeight + offset.y * beamHeight,
+            offset.z * footprint.y
+        )
+    }
+
+    private static func unitNoise(_ value: Double) -> Float {
+        Float((sin(value) + 1) * 0.5)
+    }
+}
+
 @MainActor
 final class PianoGuideOverlayController {
+    private struct KeyBeamParticle {
+        let entity: ModelEntity
+        let normalizedOffset: SIMD3<Float>
+    }
+
+    private struct KeyBeamMarker {
+        let root: Entity
+        let bodySegments: [ModelEntity]
+        let baseGlow: ModelEntity
+        let particles: [KeyBeamParticle]
+    }
+
     private var rootEntity = Entity()
     private var keyboardRootEntity = Entity()
     private var hasAttachedRoot = false
-    private var activeMarkersByMIDINote: [Int: ModelEntity] = [:]
+    private var activeMarkersByMIDINote: [Int: KeyBeamMarker] = [:]
     private var lastTintColor: UIColor?
-
-    private let lightBeamHeight: Float = 0.22
-    private let lightBeamBaseYOffset: Float = 0.006
-    private let lightBeamRadiusScale: Float = 0.32
-    private let lightBeamMinimumRadius: Float = 0.006
-    private let lightBeamAlpha: CGFloat = 0.42
 
     func updateHighlights(
         currentStep: PracticeStep?,
@@ -46,9 +157,8 @@ final class PianoGuideOverlayController {
         }
 
         if lastTintColor != tintColor {
-            let material = lightBeamMaterial(for: tintColor)
             for marker in activeMarkersByMIDINote.values {
-                marker.model?.materials = [material]
+                applyMaterials(to: marker, tintColor: tintColor)
             }
             lastTintColor = tintColor
         }
@@ -56,54 +166,99 @@ final class PianoGuideOverlayController {
         let regionByNote = Dictionary(uniqueKeysWithValues: keyRegions.map { ($0.midiNote, $0) })
         let desiredNotes: Set<Int> = Set(currentStep.notes.map(\.midiNote))
 
-        // Remove markers that are no longer needed.
-        for (midiNote, marker) in activeMarkersByMIDINote {
-            if desiredNotes.contains(midiNote) == false {
-                marker.removeFromParent()
-                activeMarkersByMIDINote[midiNote] = nil
-            }
+        let staleNotes = activeMarkersByMIDINote.keys.filter { desiredNotes.contains($0) == false }
+        for midiNote in staleNotes {
+            activeMarkersByMIDINote[midiNote]?.root.removeFromParent()
+            activeMarkersByMIDINote[midiNote] = nil
         }
 
-        // Add/update light beams for desired notes.
         for midiNote in desiredNotes {
             guard let region = regionByNote[midiNote] else { continue }
 
-            // Convert world-space key region center to keyboard-local coordinates so markers inherit the
-            // keyboard yaw from `keyboardRootEntity`.
             let centerWorld = SIMD4<Float>(region.center, 1)
             let centerLocal4 = simd_mul(keyboardFrame.keyboardFromWorld, centerWorld)
             let centerLocal = SIMD3<Float>(centerLocal4.x, centerLocal4.y, centerLocal4.z)
 
-            let marker: ModelEntity
+            let marker: KeyBeamMarker
             if let existing = activeMarkersByMIDINote[midiNote] {
                 marker = existing
             } else {
-                marker = ModelEntity(
-                    mesh: .generateCylinder(height: 1, radius: 1),
-                    materials: [lightBeamMaterial(for: tintColor)]
-                )
+                marker = makeKeyBeamMarker(midiNote: midiNote, tintColor: tintColor)
                 activeMarkersByMIDINote[midiNote] = marker
-                keyboardRootEntity.addChild(marker)
+                keyboardRootEntity.addChild(marker.root)
             }
 
-            let keyFootprint = min(region.size.x, region.size.z)
-            let beamRadius = max(keyFootprint * lightBeamRadiusScale, lightBeamMinimumRadius)
-            marker.scale = SIMD3<Float>(beamRadius, lightBeamHeight, beamRadius)
-            marker.position = SIMD3<Float>(
-                centerLocal.x,
-                centerLocal.y + lightBeamBaseYOffset + lightBeamHeight * 0.5,
-                centerLocal.z
+            update(marker: marker, region: region, centerLocal: centerLocal)
+        }
+    }
+
+    private func makeKeyBeamMarker(midiNote: Int, tintColor: UIColor) -> KeyBeamMarker {
+        let root = Entity()
+        root.name = "key-beam-\(midiNote)"
+
+        let bodySegments = (0 ..< PianoGuideBeamGeometry.bodySegmentCount).map { _ in
+            ModelEntity(mesh: .generateBox(size: 1), materials: [])
+        }
+        let baseGlow = ModelEntity(mesh: .generateBox(size: 1), materials: [])
+        let particles = PianoGuideBeamGeometry.dustParticleOffsets(for: midiNote).map { offset in
+            KeyBeamParticle(
+                entity: ModelEntity(mesh: .generateSphere(radius: 0.0012), materials: []),
+                normalizedOffset: offset
+            )
+        }
+
+        for segment in bodySegments {
+            root.addChild(segment)
+        }
+        root.addChild(baseGlow)
+        for particle in particles {
+            root.addChild(particle.entity)
+        }
+
+        let marker = KeyBeamMarker(root: root, bodySegments: bodySegments, baseGlow: baseGlow, particles: particles)
+        applyMaterials(to: marker, tintColor: tintColor)
+        return marker
+    }
+
+    private func update(marker: KeyBeamMarker, region: PianoKeyRegion, centerLocal: SIMD3<Float>) {
+        let footprint = PianoGuideBeamGeometry.beamFootprint(for: region)
+        marker.root.position = PianoGuideBeamGeometry.rootLocalPosition(centerLocal: centerLocal, region: region)
+
+        marker.baseGlow.scale = PianoGuideBeamGeometry.baseGlowScale(footprint: footprint)
+        marker.baseGlow.position = PianoGuideBeamGeometry.baseGlowPosition()
+
+        let segmentDescriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: footprint)
+        for (segment, descriptor) in zip(marker.bodySegments, segmentDescriptors) {
+            segment.scale = descriptor.scale
+            segment.position = descriptor.position
+        }
+
+        for particle in marker.particles {
+            particle.entity.position = PianoGuideBeamGeometry.dustParticlePosition(
+                offset: particle.normalizedOffset,
+                footprint: footprint
             )
         }
     }
 
-    private func lightBeamMaterial(for tintColor: UIColor) -> SimpleMaterial {
-        SimpleMaterial(color: tintColor.withAlphaComponent(lightBeamAlpha), isMetallic: false)
+    private func applyMaterials(to marker: KeyBeamMarker, tintColor: UIColor) {
+        let descriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: SIMD2<Float>(1, 1))
+        for (segment, descriptor) in zip(marker.bodySegments, descriptors) {
+            segment.model?.materials = [lightBeamMaterial(for: tintColor, alpha: descriptor.alpha)]
+        }
+        marker.baseGlow.model?.materials = [lightBeamMaterial(for: tintColor, alpha: 0.46)]
+        for particle in marker.particles {
+            particle.entity.model?.materials = [lightBeamMaterial(for: tintColor, alpha: 0.34)]
+        }
+    }
+
+    private func lightBeamMaterial(for tintColor: UIColor, alpha: CGFloat) -> SimpleMaterial {
+        SimpleMaterial(color: tintColor.withAlphaComponent(alpha), isMetallic: false)
     }
 
     private func clearMarkers() {
         for marker in activeMarkersByMIDINote.values {
-            marker.removeFromParent()
+            marker.root.removeFromParent()
         }
         activeMarkersByMIDINote.removeAll()
         lastTintColor = nil

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -78,7 +78,6 @@ final class PianoGuideOverlayController {
     private var keyboardRootEntity = Entity()
     private var hasAttachedRoot = false
     private var activeMarkersByMIDINote: [Int: KeyBeamMarker] = [:]
-    private var gradientTextureCache = BeamGradientTextureCache()
     private var lastTintColor: UIColor?
 
     func updateHighlights(
@@ -178,21 +177,11 @@ final class PianoGuideOverlayController {
     }
 
     private func gradientBeamMaterial(for tintColor: UIColor) -> UnlitMaterial {
-        if let texture = gradientTextureCache.beamTexture(for: tintColor) {
-            var material = UnlitMaterial(texture: texture)
-            material.blending = .transparent(opacity: .init(floatLiteral: 1.0))
-            return material
-        }
-
-        var fallback = UnlitMaterial(color: tintColor.withAlphaComponent(0.20))
-        fallback.blending = .transparent(opacity: .init(floatLiteral: 0.20))
-        return fallback
+        UnlitMaterial(color: tintColor.withAlphaComponent(0.20))
     }
 
     private func baseGlowMaterial(for tintColor: UIColor) -> UnlitMaterial {
-        var material = UnlitMaterial(color: tintColor.withAlphaComponent(0.42))
-        material.blending = .transparent(opacity: .init(floatLiteral: 0.42))
-        return material
+        UnlitMaterial(color: tintColor.withAlphaComponent(0.42))
     }
 
     private func clearMarkers() {
@@ -201,87 +190,5 @@ final class PianoGuideOverlayController {
         }
         activeMarkersByMIDINote.removeAll()
         lastTintColor = nil
-    }
-}
-
-@MainActor
-private struct BeamGradientTextureCache {
-    private var texturesByKey: [String: TextureResource] = [:]
-
-    mutating func beamTexture(for tintColor: UIColor) -> TextureResource? {
-        let key = cacheKey(for: tintColor)
-        if let texture = texturesByKey[key] {
-            return texture
-        }
-
-        guard let image = makeGradientImage(tintColor: tintColor) else {
-            return nil
-        }
-
-        guard let texture = try? TextureResource(
-            image: image,
-            options: TextureResource.CreateOptions(semantic: .color)
-        ) else {
-            return nil
-        }
-
-        texturesByKey[key] = texture
-        return texture
-    }
-
-    private func cacheKey(for tintColor: UIColor) -> String {
-        let components = rgbaComponents(for: tintColor)
-        return [components.red, components.green, components.blue]
-            .map { String(format: "%.4f", Double($0)) }
-            .joined(separator: ":")
-    }
-
-    private func makeGradientImage(tintColor: UIColor) -> CGImage? {
-        let width = 64
-        let height = 256
-        let components = rgbaComponents(for: tintColor)
-        var pixels = [UInt8](repeating: 0, count: width * height * 4)
-
-        for y in 0 ..< height {
-            for x in 0 ..< width {
-                let horizontal = Float(x) / Float(max(width - 1, 1))
-                let vertical = Float(y) / Float(max(height - 1, 1))
-                let alpha = Float(PianoGuideBeamGeometry.gradientAlpha(horizontal: horizontal, vertical: vertical))
-                let offset = (y * width + x) * 4
-
-                pixels[offset] = UInt8(clamping: Int(components.red * alpha * 255))
-                pixels[offset + 1] = UInt8(clamping: Int(components.green * alpha * 255))
-                pixels[offset + 2] = UInt8(clamping: Int(components.blue * alpha * 255))
-                pixels[offset + 3] = UInt8(clamping: Int(alpha * 255))
-            }
-        }
-
-        guard let provider = CGDataProvider(data: Data(pixels) as CFData) else {
-            return nil
-        }
-
-        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
-        return CGImage(
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bitsPerPixel: 32,
-            bytesPerRow: width * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: bitmapInfo,
-            provider: provider,
-            decode: nil,
-            shouldInterpolate: true,
-            intent: .defaultIntent
-        )
-    }
-
-    private func rgbaComponents(for color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-        var red: CGFloat = 1
-        var green: CGFloat = 1
-        var blue: CGFloat = 1
-        var alpha: CGFloat = 1
-        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        return (red, green, blue, alpha)
     }
 }

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -177,7 +177,7 @@ final class PianoGuideOverlayController {
         marker.baseGlow.model?.materials = [baseGlowMaterial(for: tintColor)]
     }
 
-    private func gradientBeamMaterial(for tintColor: UIColor) -> Material {
+    private func gradientBeamMaterial(for tintColor: UIColor) -> UnlitMaterial {
         if let texture = gradientTextureCache.beamTexture(for: tintColor) {
             var material = UnlitMaterial(texture: texture)
             material.blending = .transparent(opacity: .init(floatLiteral: 1.0))
@@ -189,7 +189,7 @@ final class PianoGuideOverlayController {
         return fallback
     }
 
-    private func baseGlowMaterial(for tintColor: UIColor) -> Material {
+    private func baseGlowMaterial(for tintColor: UIColor) -> UnlitMaterial {
         var material = UnlitMaterial(color: tintColor.withAlphaComponent(0.42))
         material.blending = .transparent(opacity: .init(floatLiteral: 0.42))
         return material

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import RealityKit
 import SwiftUI
+import UIKit
 
 struct PianoGuideBeamGeometry {
     static let beamHeight: Float = 0.22
@@ -57,9 +58,10 @@ struct PianoGuideBeamGeometry {
     static func gradientAlpha(horizontal: Float, vertical: Float) -> CGFloat {
         let clampedX = min(max(horizontal, 0), 1)
         let clampedY = min(max(vertical, 0), 1)
-        let centerFalloff = pow(sin(.pi * clampedX), 0.72)
-        let edgeSoftness = 0.18 + 0.82 * centerFalloff
-        let verticalFade = pow(1 - clampedY, 1.65)
+        let centerWave = sin(Double(Float.pi * clampedX))
+        let centerFalloff = Float(pow(centerWave, 0.72))
+        let edgeSoftness: Float = 0.18 + 0.82 * centerFalloff
+        let verticalFade = Float(pow(Double(1 - clampedY), 1.65))
         let baseMist: Float = 0.018
         let beamStrength: Float = 0.34
         return CGFloat((baseMist + beamStrength * verticalFade) * edgeSoftness)
@@ -109,23 +111,26 @@ final class PianoGuideOverlayController {
                 AVPOverlayPalette.feedbackWrongColor
         }
 
-        if lastTintColor != tintColor {
+        if lastTintColor?.isEqual(tintColor) != true {
             for marker in activeMarkersByMIDINote.values {
                 applyMaterials(to: marker, tintColor: tintColor)
             }
             lastTintColor = tintColor
         }
 
-        let regionByNote = Dictionary(uniqueKeysWithValues: keyRegions.map { ($0.midiNote, $0) })
-        let desiredNotes: Set<Int> = Set(currentStep.notes.map(\.midiNote))
+        let regionByNote = keyRegions.reduce(into: [Int: PianoKeyRegion]()) { partialResult, region in
+            partialResult[region.midiNote] = region
+        }
+        let desiredNotes = Set(currentStep.notes.map(\.midiNote))
+        let drawableNotes = desiredNotes.intersection(regionByNote.keys)
 
-        let staleNotes = activeMarkersByMIDINote.keys.filter { desiredNotes.contains($0) == false }
+        let staleNotes = activeMarkersByMIDINote.keys.filter { drawableNotes.contains($0) == false }
         for midiNote in staleNotes {
             activeMarkersByMIDINote[midiNote]?.root.removeFromParent()
             activeMarkersByMIDINote[midiNote] = nil
         }
 
-        for midiNote in desiredNotes {
+        for midiNote in drawableNotes {
             guard let region = regionByNote[midiNote] else { continue }
 
             let centerWorld = SIMD4<Float>(region.center, 1)
@@ -149,15 +154,19 @@ final class PianoGuideOverlayController {
         let root = Entity()
         root.name = "key-beam-\(midiNote)"
 
-        let beam = ModelEntity(mesh: .generateBox(size: 1), materials: [])
-        let baseGlow = ModelEntity(mesh: .generateBox(size: 1), materials: [])
+        let beam = ModelEntity(
+            mesh: .generateBox(size: 1),
+            materials: [gradientBeamMaterial(for: tintColor)]
+        )
+        let baseGlow = ModelEntity(
+            mesh: .generateBox(size: 1),
+            materials: [baseGlowMaterial(for: tintColor)]
+        )
 
         root.addChild(beam)
         root.addChild(baseGlow)
 
-        let marker = KeyBeamMarker(root: root, beam: beam, baseGlow: baseGlow)
-        applyMaterials(to: marker, tintColor: tintColor)
-        return marker
+        return KeyBeamMarker(root: root, beam: beam, baseGlow: baseGlow)
     }
 
     private func update(marker: KeyBeamMarker, region: PianoKeyRegion, centerLocal: SIMD3<Float>) {
@@ -176,12 +185,12 @@ final class PianoGuideOverlayController {
         marker.baseGlow.model?.materials = [baseGlowMaterial(for: tintColor)]
     }
 
-    private func gradientBeamMaterial(for tintColor: UIColor) -> UnlitMaterial {
-        UnlitMaterial(color: tintColor.withAlphaComponent(0.20))
+    private func gradientBeamMaterial(for tintColor: UIColor) -> SimpleMaterial {
+        SimpleMaterial(color: tintColor.withAlphaComponent(0.20), isMetallic: false)
     }
 
-    private func baseGlowMaterial(for tintColor: UIColor) -> UnlitMaterial {
-        UnlitMaterial(color: tintColor.withAlphaComponent(0.42))
+    private func baseGlowMaterial(for tintColor: UIColor) -> SimpleMaterial {
+        SimpleMaterial(color: tintColor.withAlphaComponent(0.42), isMetallic: false)
     }
 
     private func clearMarkers() {

--- a/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Services/RealityKit/PianoGuideOverlayController.swift
@@ -3,30 +3,16 @@ import RealityKit
 import SwiftUI
 
 struct PianoGuideBeamGeometry {
-    struct BodySegmentDescriptor {
-        let scale: SIMD3<Float>
-        let position: SIMD3<Float>
-        let alpha: CGFloat
-    }
-
     static let beamHeight: Float = 0.22
     static let beamBaseYOffset: Float = 0.006
     static let baseGlowHeight: Float = 0.004
     static let minimumBeamWidth: Float = 0.006
     static let minimumBeamDepth: Float = 0.018
-    static let bodySegmentCount = 3
-    static let dustParticleCount = 8
 
     private static let whiteKeyWidthScale: Float = 0.90
     private static let whiteKeyDepthScale: Float = 0.88
     private static let blackKeyWidthScale: Float = 0.58
     private static let blackKeyDepthScale: Float = 0.56
-    private static let bodySegmentAlphas: [CGFloat] = [0.24, 0.13, 0.055]
-    private static let bodySegmentFootprintScales: [SIMD2<Float>] = [
-        SIMD2<Float>(1.04, 1.04),
-        SIMD2<Float>(0.92, 0.90),
-        SIMD2<Float>(0.74, 0.70)
-    ]
 
     static func isBlackKey(midiNote: Int) -> Bool {
         switch midiNote % 12 {
@@ -52,6 +38,14 @@ struct PianoGuideBeamGeometry {
         return SIMD3<Float>(centerLocal.x, keyTopY + beamBaseYOffset, centerLocal.z)
     }
 
+    static func beamScale(footprint: SIMD2<Float>) -> SIMD3<Float> {
+        SIMD3<Float>(footprint.x, beamHeight, footprint.y)
+    }
+
+    static func beamPosition() -> SIMD3<Float> {
+        SIMD3<Float>(0, baseGlowHeight + beamHeight * 0.5, 0)
+    }
+
     static func baseGlowScale(footprint: SIMD2<Float>) -> SIMD3<Float> {
         SIMD3<Float>(footprint.x * 1.08, baseGlowHeight, footprint.y * 1.08)
     }
@@ -60,71 +54,31 @@ struct PianoGuideBeamGeometry {
         SIMD3<Float>(0, baseGlowHeight * 0.5, 0)
     }
 
-    static func bodySegmentDescriptors(footprint: SIMD2<Float>) -> [BodySegmentDescriptor] {
-        let segmentHeight = beamHeight / Float(bodySegmentCount)
-
-        return (0 ..< bodySegmentCount).map { index in
-            let footprintScale = bodySegmentFootprintScales[index]
-            let scale = SIMD3<Float>(
-                footprint.x * footprintScale.x,
-                segmentHeight,
-                footprint.y * footprintScale.y
-            )
-            let position = SIMD3<Float>(
-                0,
-                baseGlowHeight + segmentHeight * (Float(index) + 0.5),
-                0
-            )
-
-            return BodySegmentDescriptor(
-                scale: scale,
-                position: position,
-                alpha: bodySegmentAlphas[index]
-            )
-        }
-    }
-
-    static func dustParticleOffsets(for midiNote: Int) -> [SIMD3<Float>] {
-        (0 ..< dustParticleCount).map { index in
-            let seed = Double(midiNote * 31 + index * 17)
-            let x = (unitNoise(seed * 12.9898) - 0.5) * 0.76
-            let y = 0.14 + unitNoise(seed * 78.233) * 0.72
-            let z = (unitNoise(seed * 37.719) - 0.5) * 0.76
-            return SIMD3<Float>(x, y, z)
-        }
-    }
-
-    static func dustParticlePosition(offset: SIMD3<Float>, footprint: SIMD2<Float>) -> SIMD3<Float> {
-        SIMD3<Float>(
-            offset.x * footprint.x,
-            baseGlowHeight + offset.y * beamHeight,
-            offset.z * footprint.y
-        )
-    }
-
-    private static func unitNoise(_ value: Double) -> Float {
-        Float((sin(value) + 1) * 0.5)
+    static func gradientAlpha(horizontal: Float, vertical: Float) -> CGFloat {
+        let clampedX = min(max(horizontal, 0), 1)
+        let clampedY = min(max(vertical, 0), 1)
+        let centerFalloff = pow(sin(.pi * clampedX), 0.72)
+        let edgeSoftness = 0.18 + 0.82 * centerFalloff
+        let verticalFade = pow(1 - clampedY, 1.65)
+        let baseMist: Float = 0.018
+        let beamStrength: Float = 0.34
+        return CGFloat((baseMist + beamStrength * verticalFade) * edgeSoftness)
     }
 }
 
 @MainActor
 final class PianoGuideOverlayController {
-    private struct KeyBeamParticle {
-        let entity: ModelEntity
-        let normalizedOffset: SIMD3<Float>
-    }
-
     private struct KeyBeamMarker {
         let root: Entity
-        let bodySegments: [ModelEntity]
+        let beam: ModelEntity
         let baseGlow: ModelEntity
-        let particles: [KeyBeamParticle]
     }
 
     private var rootEntity = Entity()
     private var keyboardRootEntity = Entity()
     private var hasAttachedRoot = false
     private var activeMarkersByMIDINote: [Int: KeyBeamMarker] = [:]
+    private var gradientTextureCache = BeamGradientTextureCache()
     private var lastTintColor: UIColor?
 
     func updateHighlights(
@@ -196,26 +150,13 @@ final class PianoGuideOverlayController {
         let root = Entity()
         root.name = "key-beam-\(midiNote)"
 
-        let bodySegments = (0 ..< PianoGuideBeamGeometry.bodySegmentCount).map { _ in
-            ModelEntity(mesh: .generateBox(size: 1), materials: [])
-        }
+        let beam = ModelEntity(mesh: .generateBox(size: 1), materials: [])
         let baseGlow = ModelEntity(mesh: .generateBox(size: 1), materials: [])
-        let particles = PianoGuideBeamGeometry.dustParticleOffsets(for: midiNote).map { offset in
-            KeyBeamParticle(
-                entity: ModelEntity(mesh: .generateSphere(radius: 0.0012), materials: []),
-                normalizedOffset: offset
-            )
-        }
 
-        for segment in bodySegments {
-            root.addChild(segment)
-        }
+        root.addChild(beam)
         root.addChild(baseGlow)
-        for particle in particles {
-            root.addChild(particle.entity)
-        }
 
-        let marker = KeyBeamMarker(root: root, bodySegments: bodySegments, baseGlow: baseGlow, particles: particles)
+        let marker = KeyBeamMarker(root: root, beam: beam, baseGlow: baseGlow)
         applyMaterials(to: marker, tintColor: tintColor)
         return marker
     }
@@ -224,36 +165,34 @@ final class PianoGuideOverlayController {
         let footprint = PianoGuideBeamGeometry.beamFootprint(for: region)
         marker.root.position = PianoGuideBeamGeometry.rootLocalPosition(centerLocal: centerLocal, region: region)
 
+        marker.beam.scale = PianoGuideBeamGeometry.beamScale(footprint: footprint)
+        marker.beam.position = PianoGuideBeamGeometry.beamPosition()
+
         marker.baseGlow.scale = PianoGuideBeamGeometry.baseGlowScale(footprint: footprint)
         marker.baseGlow.position = PianoGuideBeamGeometry.baseGlowPosition()
-
-        let segmentDescriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: footprint)
-        for (segment, descriptor) in zip(marker.bodySegments, segmentDescriptors) {
-            segment.scale = descriptor.scale
-            segment.position = descriptor.position
-        }
-
-        for particle in marker.particles {
-            particle.entity.position = PianoGuideBeamGeometry.dustParticlePosition(
-                offset: particle.normalizedOffset,
-                footprint: footprint
-            )
-        }
     }
 
     private func applyMaterials(to marker: KeyBeamMarker, tintColor: UIColor) {
-        let descriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: SIMD2<Float>(1, 1))
-        for (segment, descriptor) in zip(marker.bodySegments, descriptors) {
-            segment.model?.materials = [lightBeamMaterial(for: tintColor, alpha: descriptor.alpha)]
-        }
-        marker.baseGlow.model?.materials = [lightBeamMaterial(for: tintColor, alpha: 0.46)]
-        for particle in marker.particles {
-            particle.entity.model?.materials = [lightBeamMaterial(for: tintColor, alpha: 0.34)]
-        }
+        marker.beam.model?.materials = [gradientBeamMaterial(for: tintColor)]
+        marker.baseGlow.model?.materials = [baseGlowMaterial(for: tintColor)]
     }
 
-    private func lightBeamMaterial(for tintColor: UIColor, alpha: CGFloat) -> SimpleMaterial {
-        SimpleMaterial(color: tintColor.withAlphaComponent(alpha), isMetallic: false)
+    private func gradientBeamMaterial(for tintColor: UIColor) -> Material {
+        if let texture = gradientTextureCache.beamTexture(for: tintColor) {
+            var material = UnlitMaterial(texture: texture)
+            material.blending = .transparent(opacity: .init(floatLiteral: 1.0))
+            return material
+        }
+
+        var fallback = UnlitMaterial(color: tintColor.withAlphaComponent(0.20))
+        fallback.blending = .transparent(opacity: .init(floatLiteral: 0.20))
+        return fallback
+    }
+
+    private func baseGlowMaterial(for tintColor: UIColor) -> Material {
+        var material = UnlitMaterial(color: tintColor.withAlphaComponent(0.42))
+        material.blending = .transparent(opacity: .init(floatLiteral: 0.42))
+        return material
     }
 
     private func clearMarkers() {
@@ -262,5 +201,87 @@ final class PianoGuideOverlayController {
         }
         activeMarkersByMIDINote.removeAll()
         lastTintColor = nil
+    }
+}
+
+@MainActor
+private struct BeamGradientTextureCache {
+    private var texturesByKey: [String: TextureResource] = [:]
+
+    mutating func beamTexture(for tintColor: UIColor) -> TextureResource? {
+        let key = cacheKey(for: tintColor)
+        if let texture = texturesByKey[key] {
+            return texture
+        }
+
+        guard let image = makeGradientImage(tintColor: tintColor) else {
+            return nil
+        }
+
+        guard let texture = try? TextureResource(
+            image: image,
+            options: TextureResource.CreateOptions(semantic: .color)
+        ) else {
+            return nil
+        }
+
+        texturesByKey[key] = texture
+        return texture
+    }
+
+    private func cacheKey(for tintColor: UIColor) -> String {
+        let components = rgbaComponents(for: tintColor)
+        return [components.red, components.green, components.blue]
+            .map { String(format: "%.4f", Double($0)) }
+            .joined(separator: ":")
+    }
+
+    private func makeGradientImage(tintColor: UIColor) -> CGImage? {
+        let width = 64
+        let height = 256
+        let components = rgbaComponents(for: tintColor)
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+
+        for y in 0 ..< height {
+            for x in 0 ..< width {
+                let horizontal = Float(x) / Float(max(width - 1, 1))
+                let vertical = Float(y) / Float(max(height - 1, 1))
+                let alpha = Float(PianoGuideBeamGeometry.gradientAlpha(horizontal: horizontal, vertical: vertical))
+                let offset = (y * width + x) * 4
+
+                pixels[offset] = UInt8(clamping: Int(components.red * alpha * 255))
+                pixels[offset + 1] = UInt8(clamping: Int(components.green * alpha * 255))
+                pixels[offset + 2] = UInt8(clamping: Int(components.blue * alpha * 255))
+                pixels[offset + 3] = UInt8(clamping: Int(alpha * 255))
+            }
+        }
+
+        guard let provider = CGDataProvider(data: Data(pixels) as CFData) else {
+            return nil
+        }
+
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        return CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+        )
+    }
+
+    private func rgbaComponents(for color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        var red: CGFloat = 1
+        var green: CGFloat = 1
+        var blue: CGFloat = 1
+        var alpha: CGFloat = 1
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (red, green, blue, alpha)
     }
 }

--- a/LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift
+++ b/LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift
@@ -45,38 +45,41 @@ func rectangularBeamRootStartsAboveKeyTop() {
 }
 
 @Test
-func bodySegmentsStackUpwardAndFadeTowardTop() {
+func singleGradientBeamUsesOneCuboidScaleAndPosition() {
     let footprint = SIMD2<Float>(0.02, 0.12)
-    let descriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: footprint)
 
-    #expect(descriptors.count == PianoGuideBeamGeometry.bodySegmentCount)
-    #expect(descriptors[0].position.y < descriptors[1].position.y)
-    #expect(descriptors[1].position.y < descriptors[2].position.y)
-    #expect(descriptors[0].alpha > descriptors[1].alpha)
-    #expect(descriptors[1].alpha > descriptors[2].alpha)
+    let scale = PianoGuideBeamGeometry.beamScale(footprint: footprint)
+    let position = PianoGuideBeamGeometry.beamPosition()
 
-    let expectedHeight = PianoGuideBeamGeometry.beamHeight / Float(PianoGuideBeamGeometry.bodySegmentCount)
-    for descriptor in descriptors {
-        #expect(abs(descriptor.scale.y - expectedHeight) < 1e-6)
-    }
+    #expect(abs(scale.x - 0.02) < 1e-6)
+    #expect(abs(scale.y - PianoGuideBeamGeometry.beamHeight) < 1e-6)
+    #expect(abs(scale.z - 0.12) < 1e-6)
+    #expect(abs(position.x) < 1e-6)
+    #expect(abs(position.y - (PianoGuideBeamGeometry.baseGlowHeight + PianoGuideBeamGeometry.beamHeight * 0.5)) < 1e-6)
+    #expect(abs(position.z) < 1e-6)
 }
 
 @Test
-func dustParticleOffsetsAreStableAndInsideBeamVolume() {
-    let firstOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 60)
-    let secondOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 60)
-    let differentNoteOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 61)
+func baseGlowMatchesBeamFootprint() {
+    let footprint = SIMD2<Float>(0.02, 0.12)
 
-    #expect(firstOffsets.count == PianoGuideBeamGeometry.dustParticleCount)
-    #expect(firstOffsets == secondOffsets)
-    #expect(firstOffsets != differentNoteOffsets)
+    let scale = PianoGuideBeamGeometry.baseGlowScale(footprint: footprint)
+    let position = PianoGuideBeamGeometry.baseGlowPosition()
 
-    for offset in firstOffsets {
-        #expect(offset.x >= -0.38)
-        #expect(offset.x <= 0.38)
-        #expect(offset.y >= 0.14)
-        #expect(offset.y <= 0.86)
-        #expect(offset.z >= -0.38)
-        #expect(offset.z <= 0.38)
-    }
+    #expect(abs(scale.x - 0.0216) < 1e-6)
+    #expect(abs(scale.y - PianoGuideBeamGeometry.baseGlowHeight) < 1e-6)
+    #expect(abs(scale.z - 0.1296) < 1e-6)
+    #expect(abs(position.y - PianoGuideBeamGeometry.baseGlowHeight * 0.5) < 1e-6)
+}
+
+@Test
+func gradientAlphaFadesTowardTopAndEdges() {
+    let bottomCenter = PianoGuideBeamGeometry.gradientAlpha(horizontal: 0.5, vertical: 0)
+    let topCenter = PianoGuideBeamGeometry.gradientAlpha(horizontal: 0.5, vertical: 1)
+    let bottomEdge = PianoGuideBeamGeometry.gradientAlpha(horizontal: 0, vertical: 0)
+
+    #expect(bottomCenter > topCenter)
+    #expect(bottomCenter > bottomEdge)
+    #expect(topCenter > 0)
+    #expect(bottomCenter <= 0.36)
 }

--- a/LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift
+++ b/LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift
@@ -1,0 +1,82 @@
+@testable import LonelyPianistAVP
+import simd
+import Testing
+
+@Test
+func rectangularBeamFootprintUsesKeyShapeAndKeepsBlackKeysNarrower() {
+    let whiteRegion = PianoKeyRegion(
+        midiNote: 60,
+        center: .zero,
+        size: SIMD3<Float>(0.02, 0.03, 0.14)
+    )
+    let blackRegion = PianoKeyRegion(
+        midiNote: 61,
+        center: .zero,
+        size: SIMD3<Float>(0.02, 0.03, 0.14)
+    )
+
+    let whiteFootprint = PianoGuideBeamGeometry.beamFootprint(for: whiteRegion)
+    let blackFootprint = PianoGuideBeamGeometry.beamFootprint(for: blackRegion)
+
+    #expect(PianoGuideBeamGeometry.isBlackKey(midiNote: 60) == false)
+    #expect(PianoGuideBeamGeometry.isBlackKey(midiNote: 61) == true)
+    #expect(abs(whiteFootprint.x - 0.018) < 1e-6)
+    #expect(abs(whiteFootprint.y - 0.1232) < 1e-6)
+    #expect(blackFootprint.x < whiteFootprint.x)
+    #expect(blackFootprint.y < whiteFootprint.y)
+    #expect(abs(blackFootprint.x - 0.0116) < 1e-6)
+    #expect(abs(blackFootprint.y - 0.0784) < 1e-6)
+}
+
+@Test
+func rectangularBeamRootStartsAboveKeyTop() {
+    let centerLocal = SIMD3<Float>(1.0, 2.0, 3.0)
+    let region = PianoKeyRegion(
+        midiNote: 60,
+        center: .zero,
+        size: SIMD3<Float>(0.02, 0.03, 0.14)
+    )
+
+    let rootPosition = PianoGuideBeamGeometry.rootLocalPosition(centerLocal: centerLocal, region: region)
+
+    #expect(abs(rootPosition.x - centerLocal.x) < 1e-6)
+    #expect(abs(rootPosition.y - 2.021) < 1e-6)
+    #expect(abs(rootPosition.z - centerLocal.z) < 1e-6)
+}
+
+@Test
+func bodySegmentsStackUpwardAndFadeTowardTop() {
+    let footprint = SIMD2<Float>(0.02, 0.12)
+    let descriptors = PianoGuideBeamGeometry.bodySegmentDescriptors(footprint: footprint)
+
+    #expect(descriptors.count == PianoGuideBeamGeometry.bodySegmentCount)
+    #expect(descriptors[0].position.y < descriptors[1].position.y)
+    #expect(descriptors[1].position.y < descriptors[2].position.y)
+    #expect(descriptors[0].alpha > descriptors[1].alpha)
+    #expect(descriptors[1].alpha > descriptors[2].alpha)
+
+    let expectedHeight = PianoGuideBeamGeometry.beamHeight / Float(PianoGuideBeamGeometry.bodySegmentCount)
+    for descriptor in descriptors {
+        #expect(abs(descriptor.scale.y - expectedHeight) < 1e-6)
+    }
+}
+
+@Test
+func dustParticleOffsetsAreStableAndInsideBeamVolume() {
+    let firstOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 60)
+    let secondOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 60)
+    let differentNoteOffsets = PianoGuideBeamGeometry.dustParticleOffsets(for: 61)
+
+    #expect(firstOffsets.count == PianoGuideBeamGeometry.dustParticleCount)
+    #expect(firstOffsets == secondOffsets)
+    #expect(firstOffsets != differentNoteOffsets)
+
+    for offset in firstOffsets {
+        #expect(offset.x >= -0.38)
+        #expect(offset.x <= 0.38)
+        #expect(offset.y >= 0.14)
+        #expect(offset.y <= 0.86)
+        #expect(offset.z >= -0.38)
+        #expect(offset.z <= 0.38)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the previous cylinder key guide markers with compound rectangular volumetric beams
- add key-top placement, white/black-key visual footprint scaling, base glow, three fading body segments, and deterministic dust particles
- add Swift Testing coverage for beam geometry helpers
- update DeepWiki docs for the new rectangular beam implementation

## Validation
- Added `LonelyPianistAVPTests/PianoGuideBeamGeometryTests.swift`
- PR CI should run AVP tests because this PR changes `LonelyPianistAVP/**` and `LonelyPianistAVPTests/**`

## Notes
- This does not change `PianoKeyGeometryService`, `PianoKeyRegion`, hit-testing, or practice matching behavior.
- Real optical comfort and Tyndall-style perception still require Vision Pro device tuning.