### PR TITLE
新增 AVP app 构建工作流

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -84,3 +84,26 @@ jobs:
             -scheme LonelyPianistAVP \
             -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
             CODE_SIGNING_ALLOWED=NO
+
+  avp-build:
+    name: AVP app build
+    needs: changes
+    if: needs.changes.outputs.avp == 'true'
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: List schemes
+        run: xcodebuild -list -project LonelyPianist.xcodeproj
+
+      - name: Build AVP app
+        run: |
+          xcodebuild build \
+            -project LonelyPianist.xcodeproj \
+            -scheme LonelyPianistAVP \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
在 CI 中增加了 AVP 应用构建工作流，具体实现如下：

1. 新增 `avp-build` 作业，用于构建 Apple Vision Pro 模拟器上的 AVP 应用。
2. 工作流仅在有 AVP 相关改动时触发，避免不必要的构建。

待合并后会触发 AVP 的构建流程。