### PR TITLE
统一 Step 3 自动播放与手动练习的键盘高亮规则

### DIFF
--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -37,7 +37,6 @@ final class PracticeSessionViewModel {
     private(set) var pressedNotes: Set<Int> = []
     private(set) var feedbackState: VisualFeedbackState = .none
     private(set) var isSustainPedalDown = false
-    private(set) var autoplayHighlightedMIDINotes: Set<Int> = []
     private(set) var audioRecognitionErrorMessage: String?
     private(set) var audioPlaybackErrorMessage: String?
     var audioErrorMessage: String? {
@@ -540,7 +539,6 @@ final class PracticeSessionViewModel {
         pendingReleaseOffTickByMIDI = [:]
         pendingAutoplayOnsetsByTick = [:]
         noteOutput?.allNotesOff()
-        refreshAutoplayHighlightedMIDINotes()
     }
 
     private func prepareAutoplayOnsetsForCurrentStep() {
@@ -567,8 +565,6 @@ final class PracticeSessionViewModel {
         }
 
         playPendingAutoplayOnsetsIfDue(atTick: currentStep.tick)
-
-        refreshAutoplayHighlightedMIDINotes()
     }
 
     private func playPendingAutoplayOnsetsIfDue(atTick tick: Int) {
@@ -587,8 +583,6 @@ final class PracticeSessionViewModel {
                 break
             }
         }
-
-        refreshAutoplayHighlightedMIDINotes()
     }
 
     private func handleDueNoteOffs(atTick tick: Int) {
@@ -605,10 +599,6 @@ final class PracticeSessionViewModel {
                 scheduleNoteOff(midi: midi)
             }
         }
-
-        if due.isEmpty == false {
-            refreshAutoplayHighlightedMIDINotes()
-        }
     }
 
     private func releasePendingNotesIfNeeded(atTick tick: Int) {
@@ -619,10 +609,6 @@ final class PracticeSessionViewModel {
         for (midi, _) in releasable {
             pendingReleaseOffTickByMIDI[midi] = nil
             scheduleNoteOff(midi: midi)
-        }
-
-        if releasable.isEmpty == false {
-            refreshAutoplayHighlightedMIDINotes()
         }
     }
 
@@ -636,15 +622,7 @@ final class PracticeSessionViewModel {
             guard Task.isCancelled == false else { return }
             noteOutput.noteOff(midi: midi)
             noteOffTasksByMIDI[midi] = nil
-            refreshAutoplayHighlightedMIDINotes()
         }
-        refreshAutoplayHighlightedMIDINotes()
-    }
-
-    private func refreshAutoplayHighlightedMIDINotes() {
-        autoplayHighlightedMIDINotes = Set(activeNoteOffTickByMIDI.keys)
-            .union(pendingReleaseOffTickByMIDI.keys)
-            .union(noteOffTasksByMIDI.keys)
     }
 
     private func resolveOffTick(midi: Int, staff: Int?, onTick: Int) -> Int {

--- a/LonelyPianistAVP/Views/PracticeStepView.swift
+++ b/LonelyPianistAVP/Views/PracticeStepView.swift
@@ -151,9 +151,6 @@ struct PracticeStepView: View {
     }
 
     private var highlightedMIDINotes: Set<Int> {
-        if isAutoplayEnabled {
-            return viewModel.practiceSessionViewModel.autoplayHighlightedMIDINotes
-        }
         guard let currentStep = viewModel.practiceSessionViewModel.currentStep else {
             return []
         }

--- a/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
@@ -567,7 +567,6 @@ func autoplaySchedulesNoteOffUsingNoteSpans() async {
 
     #expect(output.recordedNoteOns.map(\.midi) == [60])
     #expect(output.recordedNoteOffs.isEmpty == true)
-    #expect(viewModel.autoplayHighlightedMIDINotes == [60])
 
     for _ in 0 ..< 6 {
         await sleeper.resumeOldestPending()
@@ -578,7 +577,6 @@ func autoplaySchedulesNoteOffUsingNoteSpans() async {
     }
 
     #expect(output.recordedNoteOffs.contains(60) == true)
-    #expect(viewModel.autoplayHighlightedMIDINotes.contains(60) == false)
 }
 
 @Test
@@ -635,7 +633,6 @@ func autoplayDefersNoteOffWhilePedalIsDownAndReleasesOnPedalUp() async {
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
-    #expect(viewModel.autoplayHighlightedMIDINotes.contains(60) == true)
 
     for _ in 0 ..< 2 {
         await sleeper.resumeOldestPending()
@@ -643,7 +640,6 @@ func autoplayDefersNoteOffWhilePedalIsDownAndReleasesOnPedalUp() async {
     }
 
     #expect(output.recordedNoteOffs.contains(60) == false)
-    #expect(viewModel.autoplayHighlightedMIDINotes.contains(60) == true)
 
     for _ in 0 ..< 6 {
         await sleeper.resumeOldestPending()
@@ -654,7 +650,6 @@ func autoplayDefersNoteOffWhilePedalIsDownAndReleasesOnPedalUp() async {
     }
 
     #expect(output.recordedNoteOffs.contains(60) == true)
-    #expect(viewModel.autoplayHighlightedMIDINotes.contains(60) == false)
 }
 
 @Test


### PR DESCRIPTION
## Summary

This PR updates Step 3 keyboard highlighting so the 2D keyboard always highlights the notes from the current practice step, regardless of whether autoplay is running.

Previously, autoplay mode highlighted only the notes currently sounding during playback. This made the 2D keyboard behavior differ from the AR guide, which is based on the full `currentStep.notes` target set.

## Changes

- Use `currentStep.notes` as the single source of truth for Step 3 2D keyboard highlights.
- Remove the now-unused `autoplayHighlightedMIDINotes` ViewModel state.
- Remove `refreshAutoplayHighlightedMIDINotes()` and its call sites.
- Clean up autoplay highlight assertions in `PracticeSessionViewModelTests`.

## Behavior

- Manual practice: highlights all notes in the current step.
- Autoplay: also highlights all notes in the current step.
- Autoplay still handles note-on / note-off / pedal scheduling internally.
- AR guide behavior is unchanged.

## Validation

- Confirmed there are no remaining references to `autoplayHighlightedMIDINotes` or `refreshAutoplayHighlightedMIDINotes`.
- Run:

```bash
xcodebuild test -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -destination 'platform=visionOS Simulator,name=Apple Vision Pro'