### PR TITLE
feat: 在手动模式下可以“按小节跳转”和“重播本小节（弹一段）

### DIFF
--- a/LonelyPianistAVP/AppModel.swift
+++ b/LonelyPianistAVP/AppModel.swift
@@ -36,6 +36,7 @@ class AppModel {
 
     var importedFile: ImportedMusicXMLFile?
     var importedSteps: [PracticeStep] = []
+    var importedMeasureSpans: [MusicXMLMeasureSpan] = []
     var importErrorMessage: String?
 
     var storedCalibration: StoredWorldAnchorCalibration?
@@ -100,15 +101,17 @@ class AppModel {
     func setImportedSteps(
         _ steps: [PracticeStep],
         file: ImportedMusicXMLFile?,
-        tempoMap: MusicXMLTempoMap? = nil,
+        tempoMap: MusicXMLTempoMap,
         pedalTimeline: MusicXMLPedalTimeline? = nil,
         fermataTimeline: MusicXMLFermataTimeline? = nil,
         attributeTimeline: MusicXMLAttributeTimeline? = nil,
         slurTimeline: MusicXMLSlurTimeline? = nil,
         noteSpans: [MusicXMLNoteSpan] = [],
-        highlightGuides: [PianoHighlightGuide] = []
+        highlightGuides: [PianoHighlightGuide] = [],
+        measureSpans: [MusicXMLMeasureSpan] = []
     ) {
         importedSteps = steps
+        importedMeasureSpans = measureSpans
         importedFile = file
         importErrorMessage = nil
         practiceSessionViewModel.setSteps(
@@ -119,7 +122,8 @@ class AppModel {
             attributeTimeline: attributeTimeline,
             slurTimeline: slurTimeline,
             noteSpans: noteSpans,
-            highlightGuides: highlightGuides
+            highlightGuides: highlightGuides,
+            measureSpans: measureSpans
         )
         applySessionIfPossible()
     }
@@ -189,7 +193,8 @@ class AppModel {
                 attributeTimeline: attributeTimeline,
                 slurTimeline: slurTimeline,
                 noteSpans: noteSpans,
-                highlightGuides: highlightGuides
+                highlightGuides: highlightGuides,
+                measureSpans: practiceScore.measures
             )
         } catch {
             importErrorMessage = "导入失败：\(error.localizedDescription)"

--- a/LonelyPianistAVP/Models/Practice/ManualAdvanceMode.swift
+++ b/LonelyPianistAVP/Models/Practice/ManualAdvanceMode.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum ManualAdvanceMode: String, CaseIterable, Identifiable {
+    case step
+    case measure
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+            case .step:
+                "逐步"
+            case .measure:
+                "按小节"
+        }
+    }
+
+    var nextButtonTitle: String {
+        switch self {
+            case .step:
+                "下一步"
+            case .measure:
+                "下一节"
+        }
+    }
+
+    var replayButtonTitle: String {
+        switch self {
+            case .step:
+                "播放琴声"
+            case .measure:
+                "重播本节"
+        }
+    }
+
+    static func storageValue(from rawValue: String?) -> ManualAdvanceMode {
+        guard let rawValue else { return .step }
+        return ManualAdvanceMode(rawValue: rawValue) ?? .step
+    }
+}

--- a/LonelyPianistAVP/Services/Audio/PracticeNoteAudioPlayer.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeNoteAudioPlayer.swift
@@ -26,6 +26,10 @@ protocol PracticeMIDINoteOutputProtocol: AnyObject {
     func allNotesOff()
 }
 
+protocol PracticeMIDINoteOutputWarmupProtocol: AnyObject {
+    func warmUp() throws
+}
+
 final class SoundFontPracticeNoteAudioPlayer: PracticeNoteAudioPlayerProtocol, PracticeMIDINoteOutputProtocol {
     private let engine: AVAudioEngine
     private let sampler: AVAudioUnitSampler
@@ -131,5 +135,11 @@ final class SoundFontPracticeNoteAudioPlayer: PracticeNoteAudioPlayerProtocol, P
                 detail: error.localizedDescription
             )
         }
+    }
+}
+
+extension SoundFontPracticeNoteAudioPlayer: PracticeMIDINoteOutputWarmupProtocol {
+    func warmUp() throws {
+        try ensureReady()
     }
 }

--- a/LonelyPianistAVP/Services/Practice/ManualAdvanceStrategyProtocol.swift
+++ b/LonelyPianistAVP/Services/Practice/ManualAdvanceStrategyProtocol.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct ManualAdvanceContext {
+    let currentStepIndex: Int
+    let steps: [PracticeStep]
+    let measureSpans: [MusicXMLMeasureSpan]
+}
+
+struct ManualReplayPlan: Equatable {
+    let stepRange: Range<Int>
+}
+
+protocol ManualAdvanceStrategyProtocol {
+    func nextStepIndex(in context: ManualAdvanceContext) -> Int?
+    func replayPlan(in context: ManualAdvanceContext) -> ManualReplayPlan?
+}

--- a/LonelyPianistAVP/Services/Practice/MeasureManualAdvanceStrategy.swift
+++ b/LonelyPianistAVP/Services/Practice/MeasureManualAdvanceStrategy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct MeasureManualAdvanceStrategy: ManualAdvanceStrategyProtocol {
+    func nextStepIndex(in context: ManualAdvanceContext) -> Int? {
+        guard context.steps.isEmpty == false else { return nil }
+        guard context.steps.indices.contains(context.currentStepIndex) else { return nil }
+        guard let currentMeasureIndex = currentMeasureIndex(in: context) else {
+            return StepManualAdvanceStrategy().nextStepIndex(in: context)
+        }
+        let nextMeasureIndex = currentMeasureIndex + 1
+        guard context.measureSpans.indices.contains(nextMeasureIndex) else { return nil }
+        let nextMeasureStartTick = context.measureSpans[nextMeasureIndex].startTick
+        return context.steps.firstIndex { $0.tick >= nextMeasureStartTick }
+    }
+
+    func replayPlan(in context: ManualAdvanceContext) -> ManualReplayPlan? {
+        guard context.steps.indices.contains(context.currentStepIndex) else { return nil }
+        guard let currentMeasureIndex = currentMeasureIndex(in: context) else {
+            return StepManualAdvanceStrategy().replayPlan(in: context)
+        }
+        let span = context.measureSpans[currentMeasureIndex]
+        let indices = context.steps.indices.filter { index in
+            let tick = context.steps[index].tick
+            return tick >= span.startTick && tick < span.endTick
+        }
+        guard let lowerBound = indices.first, let upperBoundIndex = indices.last else { return nil }
+        return ManualReplayPlan(stepRange: lowerBound..<(upperBoundIndex + 1))
+    }
+
+    private func currentMeasureIndex(in context: ManualAdvanceContext) -> Int? {
+        guard context.steps.indices.contains(context.currentStepIndex) else { return nil }
+        let tick = context.steps[context.currentStepIndex].tick
+        return context.measureSpans.firstIndex { span in
+            tick >= span.startTick && tick < span.endTick
+        }
+    }
+}

--- a/LonelyPianistAVP/Services/Practice/StepManualAdvanceStrategy.swift
+++ b/LonelyPianistAVP/Services/Practice/StepManualAdvanceStrategy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct StepManualAdvanceStrategy: ManualAdvanceStrategyProtocol {
+    func nextStepIndex(in context: ManualAdvanceContext) -> Int? {
+        guard context.steps.isEmpty == false else { return nil }
+        let nextIndex = context.currentStepIndex + 1
+        return nextIndex < context.steps.count ? nextIndex : nil
+    }
+
+    func replayPlan(in context: ManualAdvanceContext) -> ManualReplayPlan? {
+        guard context.steps.indices.contains(context.currentStepIndex) else { return nil }
+        return ManualReplayPlan(stepRange: context.currentStepIndex..<(context.currentStepIndex + 1))
+    }
+}

--- a/LonelyPianistAVP/Services/Time/PracticeTimingClock.swift
+++ b/LonelyPianistAVP/Services/Time/PracticeTimingClock.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+protocol PracticeTimingClockProtocol: Sendable {
+    func nowSeconds() -> TimeInterval
+}
+
+struct ContinuousPracticeTimingClock: PracticeTimingClockProtocol {
+    private let clock = ContinuousClock()
+    private let origin: ContinuousClock.Instant
+
+    init() {
+        origin = clock.now
+    }
+
+    func nowSeconds() -> TimeInterval {
+        let components = origin.duration(to: clock.now).components
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/LonelyPianistAVP/ViewModels/ARGuideViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuideViewModel.swift
@@ -197,6 +197,10 @@ final class ARGuideViewModel {
         practiceSessionViewModel.playCurrentStepSound()
     }
 
+    func replayCurrentPracticeUnit() {
+        practiceSessionViewModel.replayCurrentUnit()
+    }
+
     func setPracticeAutoplayEnabled(_ isEnabled: Bool) {
         practiceSessionViewModel.setAutoplayEnabled(isEnabled)
     }

--- a/LonelyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
@@ -203,7 +203,8 @@ final class SongLibraryViewModel {
                 attributeTimeline: attributeTimeline,
                 slurTimeline: slurTimeline,
                 noteSpans: noteSpans,
-                highlightGuides: highlightGuides
+                highlightGuides: highlightGuides,
+                measureSpans: practiceScore.measures
             )
 
             var updatedIndex = index

--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -66,6 +66,7 @@ final class PracticeSessionViewModel {
     private let pressDetectionService: PressDetectionServiceProtocol
     private let chordAttemptAccumulator: ChordAttemptAccumulatorProtocol
     private let sleeper: SleeperProtocol
+    private let timingClock: PracticeTimingClockProtocol
     private let noteAudioPlayer: PracticeNoteAudioPlayerProtocol?
     private let noteOutput: PracticeMIDINoteOutputProtocol?
     private let audioRecognitionService: PracticeAudioRecognitionServiceProtocol?
@@ -107,6 +108,7 @@ final class PracticeSessionViewModel {
         pressDetectionService: PressDetectionServiceProtocol,
         chordAttemptAccumulator: ChordAttemptAccumulatorProtocol,
         sleeper: SleeperProtocol,
+        timingClock: PracticeTimingClockProtocol? = nil,
         noteAudioPlayer: PracticeNoteAudioPlayerProtocol?,
         noteOutput: PracticeMIDINoteOutputProtocol? = nil,
         audioRecognitionService: PracticeAudioRecognitionServiceProtocol? = nil,
@@ -119,6 +121,7 @@ final class PracticeSessionViewModel {
         self.pressDetectionService = pressDetectionService
         self.chordAttemptAccumulator = chordAttemptAccumulator
         self.sleeper = sleeper
+        self.timingClock = timingClock ?? ContinuousPracticeTimingClock()
         self.noteAudioPlayer = noteAudioPlayer
         self.noteOutput = noteOutput
         self.audioRecognitionService = audioRecognitionService
@@ -411,6 +414,11 @@ final class PracticeSessionViewModel {
     func setAutoplayEnabled(_ isEnabled: Bool) {
         if isEnabled {
             stopManualReplayTask()
+            do {
+                try (noteOutput as? PracticeMIDINoteOutputWarmupProtocol)?.warmUp()
+            } catch {
+                recordPlaybackError(error)
+            }
             autoplayState = .playing
             let tick = currentStep?.tick ?? 0
             isSustainPedalDown = pedalTimeline?.isDown(atTick: tick) ?? false
@@ -555,22 +563,25 @@ final class PracticeSessionViewModel {
         resetAutoplayCursorForCurrentStep()
         let tempoMapSnapshot = tempoMap
         let isTimingDebugEnabled = UserDefaults.standard.bool(forKey: "practiceTimingDebugEnabled")
-        let timingClock = ContinuousClock()
-        let timingStartInstant = timingClock.now
-        var timingExpectedElapsed: TimeInterval = 0
+        let timingStartWallSeconds = timingClock.nowSeconds()
+        let timingBaseTick = currentStep?.tick ?? 0
+        let timingBaseTempoSeconds = tempoMapSnapshot.timeSeconds(atTick: timingBaseTick)
+        var timingPauseOffsetSeconds: TimeInterval = 0
         var timingLoopCount = 0
 
         autoplayTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            var currentTick = currentStep?.tick ?? 0
+            var currentTick = timingBaseTick
             isSustainPedalDown = pedalTimeline?.isDown(atTick: currentTick) ?? false
-            let initialStats = await processAutoplayEventsWithStats(atTick: currentTick)
-            timingExpectedElapsed += initialStats.pauseSecondsExecuted
+            let initialStats = await processAutoplayEventsWithStats(atTick: currentTick, timingDebugEnabled: isTimingDebugEnabled)
+            timingPauseOffsetSeconds += initialStats.pauseSecondsExecuted
             if isTimingDebugEnabled {
-                let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
-                let driftSeconds = wallElapsed - timingExpectedElapsed
+                let wallElapsed = timingClock.nowSeconds() - timingStartWallSeconds
+                let expectedElapsed = (tempoMapSnapshot.timeSeconds(atTick: currentTick) - timingBaseTempoSeconds)
+                    + timingPauseOffsetSeconds
+                let driftSeconds = wallElapsed - expectedElapsed
                 timingLogger.debug(
-                    "autoplay start tick=\(currentTick, privacy: .public) expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(initialStats.eventCount, privacy: .public) pause=\(initialStats.pauseSecondsExecuted, privacy: .public)s"
+                    "autoplay start tick=\(currentTick, privacy: .public) expected=\(expectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(initialStats.eventCount, privacy: .public) pause=\(initialStats.pauseSecondsExecuted, privacy: .public)s proc=\(initialStats.processingSeconds, privacy: .public)s"
                 )
             }
 
@@ -581,13 +592,14 @@ final class PracticeSessionViewModel {
 
                 timingLoopCount += 1
                 let nextTick = autoplayTimeline.events[currentAutoplayEventIndex].tick
-                let waitSeconds = tempoMapSnapshot.durationSeconds(fromTick: currentTick, toTick: nextTick)
                 let deltaTicks = nextTick - currentTick
+                let expectedElapsed = (tempoMapSnapshot.timeSeconds(atTick: nextTick) - timingBaseTempoSeconds)
+                    + timingPauseOffsetSeconds
+                let wallElapsed = timingClock.nowSeconds() - timingStartWallSeconds
+                let waitSeconds = expectedElapsed - wallElapsed
 
-                if waitSeconds > 0 {
+                if waitSeconds >= 0.01 {
                     try? await sleeper.sleep(for: .seconds(waitSeconds))
-                } else {
-                    await Task.yield()
                 }
 
                 guard Task.isCancelled == false else { break }
@@ -595,14 +607,16 @@ final class PracticeSessionViewModel {
                 guard case .guiding = state else { break }
 
                 currentTick = nextTick
-                let stats = await processAutoplayEventsWithStats(atTick: currentTick)
-                timingExpectedElapsed += waitSeconds + stats.pauseSecondsExecuted
+                let stats = await processAutoplayEventsWithStats(atTick: currentTick, timingDebugEnabled: isTimingDebugEnabled)
+                timingPauseOffsetSeconds += stats.pauseSecondsExecuted
                 if isTimingDebugEnabled {
-                    let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
-                    let driftSeconds = wallElapsed - timingExpectedElapsed
+                    let wallElapsedAfter = timingClock.nowSeconds() - timingStartWallSeconds
+                    let expectedElapsedAfter = (tempoMapSnapshot.timeSeconds(atTick: currentTick) - timingBaseTempoSeconds)
+                        + timingPauseOffsetSeconds
+                    let driftSeconds = wallElapsedAfter - expectedElapsedAfter
                     if stats.pauseSecondsExecuted > 0 || driftSeconds > 0.05 || timingLoopCount.isMultiple(of: 50) {
                         timingLogger.debug(
-                            "autoplay tick=\(currentTick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s pause=\(stats.pauseSecondsExecuted, privacy: .public)s expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(stats.eventCount, privacy: .public) on=\(stats.noteOnCount, privacy: .public) off=\(stats.noteOffCount, privacy: .public) step=\(stats.advanceStepCount, privacy: .public) guide=\(stats.advanceGuideCount, privacy: .public)"
+                            "autoplay tick=\(currentTick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s pause=\(stats.pauseSecondsExecuted, privacy: .public)s expected=\(expectedElapsedAfter, privacy: .public)s wall=\(wallElapsedAfter, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(stats.eventCount, privacy: .public) on=\(stats.noteOnCount, privacy: .public) off=\(stats.noteOffCount, privacy: .public) step=\(stats.advanceStepCount, privacy: .public) guide=\(stats.advanceGuideCount, privacy: .public) proc=\(stats.processingSeconds, privacy: .public)s"
                         )
                     }
                 }
@@ -709,11 +723,6 @@ final class PracticeSessionViewModel {
         currentAutoplayEventIndex = autoplayTimeline.firstEventIndex(atOrAfter: tick)
     }
 
-    private func processAutoplayEvents(atTick tick: Int) async {
-        // Deprecated: kept for source compatibility only.
-        _ = await processAutoplayEventsWithStats(atTick: tick)
-    }
-
     private struct AutoplayTickStats: Equatable {
         var eventCount: Int = 0
         var noteOnCount: Int = 0
@@ -724,7 +733,29 @@ final class PracticeSessionViewModel {
         var processingSeconds: TimeInterval = 0
     }
 
-    private func processAutoplayEventsWithStats(atTick tick: Int) async -> AutoplayTickStats {
+    private func processAutoplayEventsWithStats(atTick tick: Int, timingDebugEnabled: Bool) async -> AutoplayTickStats {
+        if timingDebugEnabled == false {
+            var stats = AutoplayTickStats()
+            while currentAutoplayEventIndex < autoplayTimeline.events.count,
+                  autoplayTimeline.events[currentAutoplayEventIndex].tick == tick
+            {
+                let event = autoplayTimeline.events[currentAutoplayEventIndex]
+                currentAutoplayEventIndex += 1
+
+                if case let .pauseSeconds(seconds) = event.kind {
+                    if seconds > 0 {
+                        stats.pauseSecondsExecuted += seconds
+                        try? await sleeper.sleep(for: .seconds(seconds))
+                        guard Task.isCancelled == false else { return stats }
+                        guard autoplayState == .playing else { return stats }
+                    }
+                } else {
+                    processAutoplayEvent(event)
+                }
+            }
+            return stats
+        }
+
         let clock = ContinuousClock()
         let startInstant = clock.now
         var stats = AutoplayTickStats()
@@ -860,6 +891,11 @@ final class PracticeSessionViewModel {
         stopManualReplayTask(restoreAudioRecognition: false)
         guard plan.stepRange.isEmpty == false else { return }
         guard steps.indices.contains(plan.stepRange.lowerBound) else { return }
+        do {
+            try (noteOutput as? PracticeMIDINoteOutputWarmupProtocol)?.warmUp()
+        } catch {
+            recordPlaybackError(error)
+        }
 
         shouldResumeAudioRecognitionAfterManualReplay = shouldResumeRecognitionWhenReplayEnds
         stopAudioRecognition()
@@ -874,9 +910,9 @@ final class PracticeSessionViewModel {
 
         let tempoMapSnapshot = tempoMap
         let isTimingDebugEnabled = UserDefaults.standard.bool(forKey: "practiceTimingDebugEnabled")
-        let timingClock = ContinuousClock()
-        let timingStartInstant = timingClock.now
-        var timingExpectedElapsed: TimeInterval = 0
+        let timingStartWallSeconds = timingClock.nowSeconds()
+        let timingBaseTick = steps[startIndex].tick
+        let timingBaseTempoSeconds = tempoMapSnapshot.timeSeconds(atTick: timingBaseTick)
         var timingLoopCount = 0
         manualReplayTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -908,23 +944,21 @@ final class PracticeSessionViewModel {
 
                 let nextIndex = index + 1
                 guard plan.stepRange.contains(nextIndex), self.steps.indices.contains(nextIndex) else { continue }
-                let waitSeconds = tempoMapSnapshot.durationSeconds(
-                    fromTick: self.steps[index].tick,
-                    toTick: self.steps[nextIndex].tick
-                )
-                if waitSeconds > 0 {
+                let nextTick = self.steps[nextIndex].tick
+                let expectedElapsed = tempoMapSnapshot.timeSeconds(atTick: nextTick) - timingBaseTempoSeconds
+                let wallElapsed = timingClock.nowSeconds() - timingStartWallSeconds
+                let waitSeconds = expectedElapsed - wallElapsed
+
+                if waitSeconds >= 0.01 {
                     try? await self.sleeper.sleep(for: .seconds(waitSeconds))
-                } else {
-                    await Task.yield()
                 }
-                timingExpectedElapsed += waitSeconds
                 if isTimingDebugEnabled {
-                    let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
-                    let driftSeconds = wallElapsed - timingExpectedElapsed
+                    let wallElapsedAfter = timingClock.nowSeconds() - timingStartWallSeconds
+                    let driftSeconds = wallElapsedAfter - expectedElapsed
                     if driftSeconds > 0.05 || timingLoopCount.isMultiple(of: 50) {
                         let deltaTicks = self.steps[nextIndex].tick - self.steps[index].tick
                         timingLogger.debug(
-                            "manual replay step=\(index, privacy: .public) tick=\(self.steps[index].tick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s"
+                            "manual replay step=\(index, privacy: .public) tick=\(self.steps[index].tick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s expected=\(expectedElapsed, privacy: .public)s wall=\(wallElapsedAfter, privacy: .public)s drift=\(driftSeconds, privacy: .public)s"
                         )
                     }
                 }

--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -62,13 +62,19 @@ final class PracticeSessionViewModel {
     private let audioRecognitionService: PracticeAudioRecognitionServiceProtocol?
     private let audioStepAttemptAccumulator: AudioStepAttemptAccumulator
     private let handPianoActivityGate: HandPianoActivityGate
+    private let manualAdvanceModeProvider: () -> ManualAdvanceMode
     private var feedbackResetTask: Task<Void, Never>?
     private var autoplayTask: Task<Void, Never>?
     private var autoplayTaskGeneration = 0
     private var audioRecognitionEventsTask: Task<Void, Never>?
     private var audioRecognitionStatusTask: Task<Void, Never>?
     private var audioRecognitionDebugTask: Task<Void, Never>?
-    private var tempoMap: MusicXMLTempoMap?
+    private var tempoMap = MusicXMLTempoMap(tempoEvents: [])
+    private var measureSpans: [MusicXMLMeasureSpan] = []
+    private var manualReplayTask: Task<Void, Never>?
+    private var manualReplayGeneration = 0
+    private(set) var isManualReplayPlaying = false
+    private var shouldResumeAudioRecognitionAfterManualReplay = false
     private var pedalTimeline: MusicXMLPedalTimeline?
     private var fermataTimeline: MusicXMLFermataTimeline?
     private var attributeTimeline: MusicXMLAttributeTimeline?
@@ -96,7 +102,10 @@ final class PracticeSessionViewModel {
         noteOutput: PracticeMIDINoteOutputProtocol? = nil,
         audioRecognitionService: PracticeAudioRecognitionServiceProtocol? = nil,
         audioStepAttemptAccumulator: AudioStepAttemptAccumulator? = nil,
-        handPianoActivityGate: HandPianoActivityGate? = nil
+        handPianoActivityGate: HandPianoActivityGate? = nil,
+        manualAdvanceModeProvider: @escaping () -> ManualAdvanceMode = {
+            ManualAdvanceMode.storageValue(from: UserDefaults.standard.string(forKey: "practiceManualAdvanceMode"))
+        }
     ) {
         self.pressDetectionService = pressDetectionService
         self.chordAttemptAccumulator = chordAttemptAccumulator
@@ -106,6 +115,7 @@ final class PracticeSessionViewModel {
         self.audioRecognitionService = audioRecognitionService
         self.audioStepAttemptAccumulator = audioStepAttemptAccumulator ?? AudioStepAttemptAccumulator()
         self.handPianoActivityGate = handPianoActivityGate ?? HandPianoActivityGate()
+        self.manualAdvanceModeProvider = manualAdvanceModeProvider
         bindAudioRecognitionStreamsIfNeeded()
     }
 
@@ -189,31 +199,41 @@ final class PracticeSessionViewModel {
         return slurTimeline.isActive(atTick: currentStep.tick)
     }
 
-    func setSteps(_ steps: [PracticeStep]) {
-        setSteps(steps, tempoMap: nil, pedalTimeline: nil)
+    var manualAdvanceMode: ManualAdvanceMode {
+        manualAdvanceModeProvider()
     }
 
-    func setSteps(_ steps: [PracticeStep], tempoMap: MusicXMLTempoMap?, pedalTimeline: MusicXMLPedalTimeline? = nil) {
-        setSteps(
-            steps,
-            tempoMap: tempoMap,
-            pedalTimeline: pedalTimeline,
-            fermataTimeline: nil,
-            attributeTimeline: nil,
-            slurTimeline: nil,
-            noteSpans: []
+    var canReplayCurrentManualUnit: Bool {
+        currentStep != nil
+    }
+
+    private var manualAdvanceContext: ManualAdvanceContext {
+        ManualAdvanceContext(
+            currentStepIndex: currentStepIndex,
+            steps: steps,
+            measureSpans: measureSpans
         )
+    }
+
+    private var manualAdvanceStrategy: ManualAdvanceStrategyProtocol {
+        switch manualAdvanceMode {
+            case .step:
+                StepManualAdvanceStrategy()
+            case .measure:
+                MeasureManualAdvanceStrategy()
+        }
     }
 
     func setSteps(
         _ steps: [PracticeStep],
-        tempoMap: MusicXMLTempoMap?,
+        tempoMap: MusicXMLTempoMap,
         pedalTimeline: MusicXMLPedalTimeline? = nil,
         fermataTimeline: MusicXMLFermataTimeline? = nil,
         attributeTimeline: MusicXMLAttributeTimeline? = nil,
         slurTimeline: MusicXMLSlurTimeline? = nil,
         noteSpans: [MusicXMLNoteSpan] = [],
-        highlightGuides: [PianoHighlightGuide] = []
+        highlightGuides: [PianoHighlightGuide] = [],
+        measureSpans: [MusicXMLMeasureSpan] = []
     ) {
         if state == .completed, self.steps == steps, steps.isEmpty == false {
             return
@@ -223,6 +243,7 @@ final class PracticeSessionViewModel {
 
         feedbackResetTask?.cancel()
         feedbackResetTask = nil
+        stopManualReplayTask()
         stopAutoplayTask()
         stopAutoplayAudio()
         stopAudioRecognition()
@@ -231,6 +252,7 @@ final class PracticeSessionViewModel {
         chordAttemptAccumulator.reset()
         self.steps = steps
         self.tempoMap = tempoMap
+        self.measureSpans = measureSpans
         self.pedalTimeline = pedalTimeline
         self.fermataTimeline = fermataTimeline
         self.attributeTimeline = attributeTimeline
@@ -283,12 +305,14 @@ final class PracticeSessionViewModel {
     func resetSession() {
         feedbackResetTask?.cancel()
         feedbackResetTask = nil
+        stopManualReplayTask()
         stopAutoplayTask()
         stopAutoplayAudio()
         stopAudioRecognition()
         chordAttemptAccumulator.reset()
         steps = []
-        tempoMap = nil
+        tempoMap = MusicXMLTempoMap(tempoEvents: [])
+        measureSpans = []
         pedalTimeline = nil
         fermataTimeline = nil
         attributeTimeline = nil
@@ -345,10 +369,17 @@ final class PracticeSessionViewModel {
     }
 
     func skip() {
+        stopManualReplayTask()
         stopAutoplayTask()
         stopAutoplayAudio()
-        advanceToNextStep()
+        advanceToNextManualUnit()
         startAutoplayTaskIfNeeded()
+    }
+
+    func replayCurrentUnit() {
+        guard autoplayState == .off else { return }
+        guard let plan = manualAdvanceStrategy.replayPlan(in: manualAdvanceContext) else { return }
+        startManualReplay(with: plan)
     }
 
     func playCurrentStepSound() {
@@ -370,6 +401,7 @@ final class PracticeSessionViewModel {
 
     func setAutoplayEnabled(_ isEnabled: Bool) {
         if isEnabled {
+            stopManualReplayTask()
             autoplayState = .playing
             let tick = currentStep?.tick ?? 0
             isSustainPedalDown = pedalTimeline?.isDown(atTick: tick) ?? false
@@ -397,7 +429,7 @@ final class PracticeSessionViewModel {
                 keyboardGeometry: keyboardGeometry,
                 exactPressedNotes: detected
             )
-            if autoplayState == .off, let currentStep {
+            if autoplayState == .off, isManualReplayPlaying == false, let currentStep {
                 let expected = uniqueMIDINotes(in: currentStep)
                 let isMatched = chordAttemptAccumulator.register(
                     pressedNotes: detected,
@@ -429,6 +461,18 @@ final class PracticeSessionViewModel {
         return detected
     }
 
+    private func advanceToNextManualUnit() {
+        guard steps.isEmpty == false else {
+            state = .idle
+            return
+        }
+        guard let nextIndex = manualAdvanceStrategy.nextStepIndex(in: manualAdvanceContext) else {
+            completeManualAdvance()
+            return
+        }
+        moveToStep(nextIndex, shouldPlaySound: autoplayState == .off)
+    }
+
     private func advanceToNextStep() {
         guard steps.isEmpty == false else {
             state = .idle
@@ -458,6 +502,34 @@ final class PracticeSessionViewModel {
         }
     }
 
+    private func moveToStep(_ nextStepIndex: Int, shouldPlaySound: Bool) {
+        guard steps.indices.contains(nextStepIndex) else {
+            completeManualAdvance()
+            return
+        }
+        let previousTick = steps.indices.contains(currentStepIndex) ? steps[currentStepIndex].tick : steps[nextStepIndex].tick
+        chordAttemptAccumulator.reset()
+        currentStepIndex = nextStepIndex
+        state = .guiding(stepIndex: nextStepIndex)
+        updateHighlightGuideAfterStepAdvance(previousTick: previousTick, nextStepIndex: nextStepIndex)
+        refreshAudioRecognitionForCurrentState()
+        if shouldPlaySound {
+            _ = prepareAudioRecognitionSuppressWindowForPlayback()
+            playCurrentStepSound(applyRecognitionSuppress: false)
+        }
+    }
+
+    private func completeManualAdvance() {
+        currentStepIndex = steps.count
+        currentHighlightGuideIndex = nil
+        pressedNotes.removeAll()
+        state = .completed
+        stopManualReplayTask()
+        stopAutoplayTask()
+        stopAutoplayAudio()
+        stopAudioRecognition()
+    }
+
     private func startAutoplayTaskIfNeeded() {
         guard autoplayState == .playing else { return }
         guard case .guiding = state else { return }
@@ -472,10 +544,7 @@ final class PracticeSessionViewModel {
         autoplayTaskGeneration += 1
         let generation = autoplayTaskGeneration
         resetAutoplayCursorForCurrentStep()
-        guard let tempoMapSnapshot = tempoMap else {
-            stopAutoplayWithError("无法自动播放：缺少速度信息（tempo）。请重新导入这份 MusicXML。")
-            return
-        }
+        let tempoMapSnapshot = tempoMap
 
         autoplayTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -513,9 +582,6 @@ final class PracticeSessionViewModel {
     private func autoplayStartErrorMessage() -> String? {
         guard noteOutput != nil else {
             return "无法自动播放：音频输出未就绪。请重启 App 或重新打开曲目。"
-        }
-        guard tempoMap != nil else {
-            return "无法自动播放：缺少速度信息（tempo）。请重新导入这份 MusicXML。"
         }
         guard pedalTimeline != nil else {
             return "无法自动播放：缺少踏板信息。请重新导入这份 MusicXML。"
@@ -585,7 +651,6 @@ final class PracticeSessionViewModel {
 
     private func rebuildAutoplayTimeline() {
         guard
-            let tempoMap,
             let pedalTimeline,
             let fermataTimeline,
             highlightGuides.isEmpty == false
@@ -718,6 +783,82 @@ final class PracticeSessionViewModel {
     }
 
 
+    private func startManualReplay(with plan: ManualReplayPlan) {
+        let shouldResumeRecognitionWhenReplayEnds = isManualReplayPlaying
+            ? shouldResumeAudioRecognitionAfterManualReplay
+            : isAudioRecognitionRunning
+        stopManualReplayTask(restoreAudioRecognition: false)
+        guard plan.stepRange.isEmpty == false else { return }
+        guard steps.indices.contains(plan.stepRange.lowerBound) else { return }
+
+        shouldResumeAudioRecognitionAfterManualReplay = shouldResumeRecognitionWhenReplayEnds
+        stopAudioRecognition()
+        feedbackResetTask?.cancel()
+        feedbackResetTask = nil
+        feedbackState = .none
+        manualReplayGeneration += 1
+        let generation = manualReplayGeneration
+        let startIndex = plan.stepRange.lowerBound
+        isManualReplayPlaying = true
+        moveToStep(startIndex, shouldPlaySound: false)
+
+        let tempoMapSnapshot = tempoMap
+        manualReplayTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var completedReplay = false
+            defer {
+                if self.manualReplayGeneration == generation {
+                    if completedReplay, self.steps.indices.contains(startIndex) {
+                        self.currentStepIndex = startIndex
+                        self.state = .guiding(stepIndex: startIndex)
+                        self.setCurrentHighlightGuideForStepIndex(startIndex)
+                    }
+                    self.manualReplayTask = nil
+                    self.isManualReplayPlaying = false
+                    if self.shouldResumeAudioRecognitionAfterManualReplay {
+                        self.refreshAudioRecognitionForCurrentState()
+                    }
+                    self.shouldResumeAudioRecognitionAfterManualReplay = false
+                }
+            }
+
+            for index in plan.stepRange {
+                guard Task.isCancelled == false else { return }
+                guard self.steps.indices.contains(index) else { return }
+                self.currentStepIndex = index
+                self.state = .guiding(stepIndex: index)
+                self.setCurrentHighlightGuideForStepIndex(index)
+                self.playCurrentStepSound(applyRecognitionSuppress: false)
+
+                let nextIndex = index + 1
+                guard plan.stepRange.contains(nextIndex), self.steps.indices.contains(nextIndex) else { continue }
+                let waitSeconds = tempoMapSnapshot.durationSeconds(
+                    fromTick: self.steps[index].tick,
+                    toTick: self.steps[nextIndex].tick
+                )
+                if waitSeconds > 0 {
+                    try? await self.sleeper.sleep(for: .seconds(waitSeconds))
+                } else {
+                    await Task.yield()
+                }
+            }
+            completedReplay = true
+        }
+    }
+
+    private func stopManualReplayTask(restoreAudioRecognition: Bool = true) {
+        manualReplayGeneration += 1
+        manualReplayTask?.cancel()
+        manualReplayTask = nil
+        if isManualReplayPlaying {
+            isManualReplayPlaying = false
+            if restoreAudioRecognition, shouldResumeAudioRecognitionAfterManualReplay {
+                refreshAudioRecognitionForCurrentState()
+            }
+        }
+        shouldResumeAudioRecognitionAfterManualReplay = false
+    }
+
     private func uniqueMIDINotes(in step: PracticeStep) -> [Int] {
         Set(step.notes.map(\.midiNote)).sorted()
     }
@@ -794,6 +935,10 @@ final class PracticeSessionViewModel {
             return
         }
         guard autoplayState == .off else {
+            stopAudioRecognition()
+            return
+        }
+        guard isManualReplayPlaying == false else {
             stopAudioRecognition()
             return
         }
@@ -897,6 +1042,7 @@ final class PracticeSessionViewModel {
     private func handleAudioRecognitionEvent(_ event: DetectedNoteEvent) {
         guard isPracticeAudioRecognitionEnabled else { return }
         guard autoplayState == .off else { return }
+        guard isManualReplayPlaying == false else { return }
         guard event.generation == audioRecognitionGeneration else { return }
         if let audioRecognitionSuppressUntil, event.timestamp <= audioRecognitionSuppressUntil {
             decisionLogger.debug("audio event suppressed generation=\(event.generation, privacy: .public)")
@@ -949,6 +1095,10 @@ final class PracticeSessionViewModel {
         audioRecognitionEnabledSnapshot
     }
 
+
+    var audioRecognitionGenerationForTesting: Int {
+        audioRecognitionGeneration
+    }
 
     var audioRecognitionSuppressRemainingSeconds: TimeInterval {
         guard let audioRecognitionSuppressUntil else { return 0 }

--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -721,9 +721,12 @@ final class PracticeSessionViewModel {
         var advanceStepCount: Int = 0
         var advanceGuideCount: Int = 0
         var pauseSecondsExecuted: TimeInterval = 0
+        var processingSeconds: TimeInterval = 0
     }
 
     private func processAutoplayEventsWithStats(atTick tick: Int) async -> AutoplayTickStats {
+        let clock = ContinuousClock()
+        let startInstant = clock.now
         var stats = AutoplayTickStats()
         while currentAutoplayEventIndex < autoplayTimeline.events.count,
               autoplayTimeline.events[currentAutoplayEventIndex].tick == tick
@@ -757,6 +760,7 @@ final class PracticeSessionViewModel {
                 processAutoplayEvent(event)
             }
         }
+        stats.processingSeconds = Self.durationSeconds(startInstant.duration(to: clock.now))
         return stats
     }
 

--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -10,6 +10,15 @@ final class PracticeSessionViewModel {
         subsystem: Bundle.main.bundleIdentifier ?? "LonelyPianistAVP",
         category: "Step3AudioDecision"
     )
+    private let timingLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "LonelyPianistAVP",
+        category: "Step3PracticeTiming"
+    )
+
+    private static func durationSeconds(_ duration: Duration) -> TimeInterval {
+        let components = duration.components
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+    }
 
     enum VisualFeedbackState: Equatable {
         case none
@@ -545,20 +554,35 @@ final class PracticeSessionViewModel {
         let generation = autoplayTaskGeneration
         resetAutoplayCursorForCurrentStep()
         let tempoMapSnapshot = tempoMap
+        let isTimingDebugEnabled = UserDefaults.standard.bool(forKey: "practiceTimingDebugEnabled")
+        let timingClock = ContinuousClock()
+        let timingStartInstant = timingClock.now
+        var timingExpectedElapsed: TimeInterval = 0
+        var timingLoopCount = 0
 
         autoplayTask = Task { @MainActor [weak self] in
             guard let self else { return }
             var currentTick = currentStep?.tick ?? 0
             isSustainPedalDown = pedalTimeline?.isDown(atTick: currentTick) ?? false
-            await processAutoplayEvents(atTick: currentTick)
+            let initialStats = await processAutoplayEventsWithStats(atTick: currentTick)
+            timingExpectedElapsed += initialStats.pauseSecondsExecuted
+            if isTimingDebugEnabled {
+                let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
+                let driftSeconds = wallElapsed - timingExpectedElapsed
+                timingLogger.debug(
+                    "autoplay start tick=\(currentTick, privacy: .public) expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(initialStats.eventCount, privacy: .public) pause=\(initialStats.pauseSecondsExecuted, privacy: .public)s"
+                )
+            }
 
             while Task.isCancelled == false {
                 guard autoplayState == .playing else { break }
                 guard case .guiding = state else { break }
                 guard currentAutoplayEventIndex < autoplayTimeline.events.count else { break }
 
+                timingLoopCount += 1
                 let nextTick = autoplayTimeline.events[currentAutoplayEventIndex].tick
                 let waitSeconds = tempoMapSnapshot.durationSeconds(fromTick: currentTick, toTick: nextTick)
+                let deltaTicks = nextTick - currentTick
 
                 if waitSeconds > 0 {
                     try? await sleeper.sleep(for: .seconds(waitSeconds))
@@ -571,7 +595,17 @@ final class PracticeSessionViewModel {
                 guard case .guiding = state else { break }
 
                 currentTick = nextTick
-                await processAutoplayEvents(atTick: currentTick)
+                let stats = await processAutoplayEventsWithStats(atTick: currentTick)
+                timingExpectedElapsed += waitSeconds + stats.pauseSecondsExecuted
+                if isTimingDebugEnabled {
+                    let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
+                    let driftSeconds = wallElapsed - timingExpectedElapsed
+                    if stats.pauseSecondsExecuted > 0 || driftSeconds > 0.05 || timingLoopCount.isMultiple(of: 50) {
+                        timingLogger.debug(
+                            "autoplay tick=\(currentTick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s pause=\(stats.pauseSecondsExecuted, privacy: .public)s expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s events=\(stats.eventCount, privacy: .public) on=\(stats.noteOnCount, privacy: .public) off=\(stats.noteOffCount, privacy: .public) step=\(stats.advanceStepCount, privacy: .public) guide=\(stats.advanceGuideCount, privacy: .public)"
+                        )
+                    }
+                }
             }
 
             guard self.autoplayTaskGeneration == generation else { return }
@@ -676,22 +710,54 @@ final class PracticeSessionViewModel {
     }
 
     private func processAutoplayEvents(atTick tick: Int) async {
+        // Deprecated: kept for source compatibility only.
+        _ = await processAutoplayEventsWithStats(atTick: tick)
+    }
+
+    private struct AutoplayTickStats: Equatable {
+        var eventCount: Int = 0
+        var noteOnCount: Int = 0
+        var noteOffCount: Int = 0
+        var advanceStepCount: Int = 0
+        var advanceGuideCount: Int = 0
+        var pauseSecondsExecuted: TimeInterval = 0
+    }
+
+    private func processAutoplayEventsWithStats(atTick tick: Int) async -> AutoplayTickStats {
+        var stats = AutoplayTickStats()
         while currentAutoplayEventIndex < autoplayTimeline.events.count,
               autoplayTimeline.events[currentAutoplayEventIndex].tick == tick
         {
             let event = autoplayTimeline.events[currentAutoplayEventIndex]
             currentAutoplayEventIndex += 1
+            stats.eventCount += 1
 
             if case let .pauseSeconds(seconds) = event.kind {
                 if seconds > 0 {
+                    stats.pauseSecondsExecuted += seconds
                     try? await sleeper.sleep(for: .seconds(seconds))
-                    guard Task.isCancelled == false else { return }
-                    guard autoplayState == .playing else { return }
+                    guard Task.isCancelled == false else { return stats }
+                    guard autoplayState == .playing else { return stats }
                 }
             } else {
+                switch event.kind {
+                    case .noteOn:
+                        stats.noteOnCount += 1
+                    case .noteOff:
+                        stats.noteOffCount += 1
+                    case .advanceStep:
+                        stats.advanceStepCount += 1
+                    case .advanceGuide:
+                        stats.advanceGuideCount += 1
+                    case .pauseSeconds:
+                        break
+                    case .pedalDown, .pedalUp:
+                        break
+                }
                 processAutoplayEvent(event)
             }
         }
+        return stats
     }
 
     private func processAutoplayEvent(_ event: AutoplayPerformanceTimeline.Event) {
@@ -803,6 +869,11 @@ final class PracticeSessionViewModel {
         moveToStep(startIndex, shouldPlaySound: false)
 
         let tempoMapSnapshot = tempoMap
+        let isTimingDebugEnabled = UserDefaults.standard.bool(forKey: "practiceTimingDebugEnabled")
+        let timingClock = ContinuousClock()
+        let timingStartInstant = timingClock.now
+        var timingExpectedElapsed: TimeInterval = 0
+        var timingLoopCount = 0
         manualReplayTask = Task { @MainActor [weak self] in
             guard let self else { return }
             var completedReplay = false
@@ -825,6 +896,7 @@ final class PracticeSessionViewModel {
             for index in plan.stepRange {
                 guard Task.isCancelled == false else { return }
                 guard self.steps.indices.contains(index) else { return }
+                timingLoopCount += 1
                 self.currentStepIndex = index
                 self.state = .guiding(stepIndex: index)
                 self.setCurrentHighlightGuideForStepIndex(index)
@@ -840,6 +912,17 @@ final class PracticeSessionViewModel {
                     try? await self.sleeper.sleep(for: .seconds(waitSeconds))
                 } else {
                     await Task.yield()
+                }
+                timingExpectedElapsed += waitSeconds
+                if isTimingDebugEnabled {
+                    let wallElapsed = Self.durationSeconds(timingStartInstant.duration(to: timingClock.now))
+                    let driftSeconds = wallElapsed - timingExpectedElapsed
+                    if driftSeconds > 0.05 || timingLoopCount.isMultiple(of: 50) {
+                        let deltaTicks = self.steps[nextIndex].tick - self.steps[index].tick
+                        timingLogger.debug(
+                            "manual replay step=\(index, privacy: .public) tick=\(self.steps[index].tick, privacy: .public) Δtick=\(deltaTicks, privacy: .public) wait=\(waitSeconds, privacy: .public)s expected=\(timingExpectedElapsed, privacy: .public)s wall=\(wallElapsed, privacy: .public)s drift=\(driftSeconds, privacy: .public)s"
+                        )
+                    }
                 }
             }
             completedReplay = true

--- a/LonelyPianistAVP/Views/ContentView.swift
+++ b/LonelyPianistAVP/Views/ContentView.swift
@@ -167,7 +167,8 @@ private struct StepOrbLink: View {
             PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
             PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
         ],
-        file: nil
+        file: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
     )
     return ContentView(
         homeViewModel: HomeViewModel(appModel: appModel),

--- a/LonelyPianistAVP/Views/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/PracticeSettingsView.swift
@@ -4,11 +4,19 @@ struct PracticeSettingsView: View {
     @AppStorage("practiceAudioRecognitionDebugOverlayEnabled") private var practiceAudioRecognitionDebugOverlayEnabled =
         false
     @AppStorage("debugKeyboardAxesOverlayEnabled") private var debugKeyboardAxesOverlayEnabled = false
+    @AppStorage("practiceManualAdvanceMode") private var manualAdvanceModeRawValue = ManualAdvanceMode.step.rawValue
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Toggle("调试：显示音频识别 overlay", isOn: $practiceAudioRecognitionDebugOverlayEnabled)
             Toggle("调试：显示键盘坐标轴（X/Y/Z）", isOn: $debugKeyboardAxesOverlayEnabled)
+
+            Picker("手动前进方式", selection: $manualAdvanceModeRawValue) {
+                ForEach(ManualAdvanceMode.allCases) { mode in
+                    Text(mode.title).tag(mode.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
         }
         .padding(16)
         .frame(minWidth: 320)

--- a/LonelyPianistAVP/Views/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/PracticeSettingsView.swift
@@ -4,12 +4,14 @@ struct PracticeSettingsView: View {
     @AppStorage("practiceAudioRecognitionDebugOverlayEnabled") private var practiceAudioRecognitionDebugOverlayEnabled =
         false
     @AppStorage("debugKeyboardAxesOverlayEnabled") private var debugKeyboardAxesOverlayEnabled = false
+    @AppStorage("practiceTimingDebugEnabled") private var practiceTimingDebugEnabled = false
     @AppStorage("practiceManualAdvanceMode") private var manualAdvanceModeRawValue = ManualAdvanceMode.step.rawValue
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Toggle("调试：显示音频识别 overlay", isOn: $practiceAudioRecognitionDebugOverlayEnabled)
             Toggle("调试：显示键盘坐标轴（X/Y/Z）", isOn: $debugKeyboardAxesOverlayEnabled)
+            Toggle("调试：输出节奏日志（autoplay / 回放）", isOn: $practiceTimingDebugEnabled)
 
             Picker("手动前进方式", selection: $manualAdvanceModeRawValue) {
                 ForEach(ManualAdvanceMode.allCases) { mode in

--- a/LonelyPianistAVP/Views/PracticeStepView.swift
+++ b/LonelyPianistAVP/Views/PracticeStepView.swift
@@ -15,6 +15,7 @@ struct PracticeStepView: View {
     @State private var isAutoplayErrorAlertPresented = false
 
     @AppStorage("practiceStep3AutoplayEnabled") private var isAutoplayEnabled = false
+    @AppStorage("practiceManualAdvanceMode") private var manualAdvanceModeRawValue = ManualAdvanceMode.step.rawValue
     @AppStorage("practiceAudioRecognitionDebugOverlayEnabled") private var isAudioDebugOverlayEnabled = false
 
     var body: some View {
@@ -50,7 +51,7 @@ struct PracticeStepView: View {
                     .hoverEffect()
 
                     if isAutoplayEnabled == false {
-                        Button("下一步", systemImage: "forward.fill") {
+                        Button(manualAdvanceMode.nextButtonTitle, systemImage: "forward.fill") {
                             viewModel.skipStep()
                         }
                         .buttonStyle(.bordered)
@@ -59,8 +60,12 @@ struct PracticeStepView: View {
                         .disabled(viewModel.hasImportedSteps == false || viewModel.practiceSessionViewModel
                             .state == .completed)
 
-                        Button("播放琴声", systemImage: "speaker.wave.2.fill") {
-                            viewModel.playCurrentPracticeStepSound()
+                        Button(manualAdvanceMode.replayButtonTitle, systemImage: "speaker.wave.2.fill") {
+                            if manualAdvanceMode == .measure {
+                                viewModel.replayCurrentPracticeUnit()
+                            } else {
+                                viewModel.playCurrentPracticeStepSound()
+                            }
                         }
                         .buttonStyle(.bordered)
                         .buttonBorderShape(.roundedRectangle)
@@ -159,6 +164,10 @@ struct PracticeStepView: View {
                     await viewModel.recoverImmersiveStateIfStuck()
                 }
             }
+    }
+
+    private var manualAdvanceMode: ManualAdvanceMode {
+        ManualAdvanceMode.storageValue(from: manualAdvanceModeRawValue)
     }
 
     private var highlightedMIDINotes: Set<Int> {

--- a/LonelyPianistAVPTests/HandPianoActivityGateTests.swift
+++ b/LonelyPianistAVPTests/HandPianoActivityGateTests.swift
@@ -42,7 +42,9 @@ func exactHitFallbackStillAdvancesStep() {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.applyKeyboardGeometry(
         makeDummyKeyboardGeometry(),
         calibration: PianoCalibration(a0: .zero, c8: SIMD3<Float>(1, 0, 0), planeHeight: 0)
@@ -69,7 +71,9 @@ func gateInactiveStillAllowsAudioMatchedAdvance() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
     let generation = fakeService.startCalls.first?.generation ?? 0

--- a/LonelyPianistAVPTests/HomeViewModelTests.swift
+++ b/LonelyPianistAVPTests/HomeViewModelTests.swift
@@ -118,8 +118,9 @@ private func makeAppModel(
     if hasImportedSteps {
         appModel.setImportedSteps(
             [PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)])],
-            file: nil
-        )
+            file: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     }
 
     return appModel

--- a/LonelyPianistAVPTests/ManualAdvanceStrategyTests.swift
+++ b/LonelyPianistAVPTests/ManualAdvanceStrategyTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+@testable import LonelyPianistAVP
+import Testing
+
+@Test
+func measureNextStepFromMeasureStartJumpsToNextMeasureStart() {
+    let strategy = MeasureManualAdvanceStrategy()
+    let context = makeManualAdvanceContext(currentStepIndex: 0)
+    #expect(strategy.nextStepIndex(in: context) == 2)
+}
+
+@Test
+func measureNextStepFromMiddleJumpsToNextMeasureStart() {
+    let strategy = MeasureManualAdvanceStrategy()
+    let context = makeManualAdvanceContext(currentStepIndex: 1)
+    #expect(strategy.nextStepIndex(in: context) == 2)
+}
+
+@Test
+func measureNextStepSkipsEmptyMeasureToFollowingStep() {
+    let strategy = MeasureManualAdvanceStrategy()
+    let context = makeManualAdvanceContext(currentStepIndex: 2)
+    #expect(strategy.nextStepIndex(in: context) == 3)
+}
+
+@Test
+func measureNextStepFromLastMeasureCompletes() {
+    let strategy = MeasureManualAdvanceStrategy()
+    let context = makeManualAdvanceContext(currentStepIndex: 3)
+    #expect(strategy.nextStepIndex(in: context) == nil)
+}
+
+private func makeManualAdvanceContext(currentStepIndex: Int) -> ManualAdvanceContext {
+    ManualAdvanceContext(
+        currentStepIndex: currentStepIndex,
+        steps: [
+            PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)]),
+            PracticeStep(tick: 240, notes: [PracticeStepNote(midiNote: 62, staff: 1)]),
+            PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 64, staff: 1)]),
+            PracticeStep(tick: 1440, notes: [PracticeStepNote(midiNote: 65, staff: 1)]),
+        ],
+        measureSpans: [
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 1, startTick: 0, endTick: 480),
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 2, startTick: 480, endTick: 960),
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 3, startTick: 960, endTick: 1440),
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 4, startTick: 1440, endTick: 1920),
+        ]
+    )
+}
+
+@Test
+@MainActor
+func appModelPassesMeasureSpansToPracticeSession() {
+    let sessionViewModel = PracticeSessionViewModel(
+        pressDetectionService: ManualAdvanceNoopPressDetectionService(),
+        chordAttemptAccumulator: ManualAdvanceNoopChordAttemptAccumulator(),
+        sleeper: TaskSleeper(),
+        noteAudioPlayer: ManualAdvanceSilentAudioPlayer(),
+        manualAdvanceModeProvider: { .measure }
+    )
+    let appModel = AppModel(practiceSessionViewModel: sessionViewModel)
+    appModel.setImportedSteps(
+        [
+            PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)]),
+            PracticeStep(tick: 240, notes: [PracticeStepNote(midiNote: 62, staff: 1)]),
+            PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 64, staff: 1)]),
+        ],
+        file: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: []),
+        measureSpans: [
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 1, startTick: 0, endTick: 480),
+            MusicXMLMeasureSpan(partID: "P1", measureNumber: 2, startTick: 480, endTick: 960),
+        ]
+    )
+
+    sessionViewModel.skip()
+
+    #expect(sessionViewModel.currentStepIndex == 2)
+}
+
+private struct ManualAdvanceNoopPressDetectionService: PressDetectionServiceProtocol {
+    func detectPressedNotes(fingerTips _: [String: SIMD3<Float>], keyboardGeometry _: PianoKeyboardGeometry?, at _: Date) -> Set<Int> { [] }
+}
+
+private final class ManualAdvanceNoopChordAttemptAccumulator: ChordAttemptAccumulatorProtocol {
+    func register(pressedNotes _: Set<Int>, expectedNotes _: [Int], tolerance _: Int, at _: Date) -> Bool { false }
+    func reset() {}
+}
+
+private final class ManualAdvanceSilentAudioPlayer: PracticeNoteAudioPlayerProtocol {
+    func play(midiNotes _: [Int]) throws {}
+}

--- a/LonelyPianistAVPTests/PracticeLocalizationPolicyTests.swift
+++ b/LonelyPianistAVPTests/PracticeLocalizationPolicyTests.swift
@@ -22,7 +22,8 @@ func practiceEntryBlockingReasonIsMissingStoredCalibrationWhenStepsExist() {
     let appModel = AppModel()
     appModel.setImportedSteps(
         [PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)])],
-        file: nil
+        file: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
     )
 
     let viewModel = ARGuideViewModel(appModel: appModel)
@@ -40,7 +41,8 @@ func practiceEntryBlockingReasonIsNilWhenPreconditionsAreReady() {
     )
     appModel.setImportedSteps(
         [PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)])],
-        file: nil
+        file: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
     )
 
     let viewModel = ARGuideViewModel(appModel: appModel)

--- a/LonelyPianistAVPTests/PracticeSessionAudioRecognitionTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionAudioRecognitionTests.swift
@@ -62,7 +62,9 @@ func guidingStartsAudioRecognitionService() async {
     let viewModel = makeViewModel(audioRecognitionService: fakeService)
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -80,7 +82,9 @@ func switchingStepUpdatesGenerationAndExpectedNotes() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -102,7 +106,9 @@ func staleGenerationEventDoesNotAdvanceStep() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -133,7 +139,9 @@ func matchingAudioEventAdvancesStep() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -171,7 +179,9 @@ func suppressWindowBlocksThenAllowsAdvance() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
     let generation = fakeService.startCalls.first?.generation ?? 0
@@ -316,7 +326,9 @@ func permissionFailureStatusDoesNotAdvanceAndSetsError() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -399,7 +411,9 @@ func startGuidingPassesPlaybackSuppressDeadlineIntoAudioServiceStart() async {
     )
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -423,7 +437,9 @@ func microphonePermissionFailureDoesNotBlockPlaybackFallback() async {
     )
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
 
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
@@ -443,7 +459,9 @@ func disablingAudioRecognitionSettingStopsRunningService() async {
     let viewModel = makeViewModel(audioRecognitionService: fakeService)
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
@@ -462,7 +480,9 @@ func disablingAudioRecognitionSettingIgnoresQueuedEvents() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 10, notes: [PracticeStepNote(midiNote: 64, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
     let generation = fakeService.startCalls.first?.generation ?? 0

--- a/LonelyPianistAVPTests/PracticeSessionReplayGateTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionReplayGateTests.swift
@@ -25,6 +25,8 @@ func manualReplayBlocksGestureAdvance() async {
 
     #expect(viewModel.isManualReplayPlaying)
     #expect(viewModel.currentStepIndex == before)
+
+    viewModel.resetSession()
 }
 
 @Test
@@ -62,6 +64,8 @@ func manualReplayBlocksAudioRecognitionAdvance() async {
 
     #expect(viewModel.isManualReplayPlaying)
     #expect(viewModel.currentStepIndex == before)
+
+    viewModel.resetSession()
 }
 
 
@@ -81,12 +85,17 @@ func completedManualReplayReturnsProgressToMeasureStart() async {
     #expect(viewModel.currentStepIndex == 1)
 
     viewModel.replayCurrentUnit()
-    await Task.yield()
-    await Task.yield()
-    await Task.yield()
+    for _ in 0 ..< 32 {
+        if viewModel.isManualReplayPlaying == false {
+            break
+        }
+        await Task.yield()
+    }
 
     #expect(viewModel.isManualReplayPlaying == false)
     #expect(viewModel.currentStepIndex == 0)
+
+    viewModel.resetSession()
 }
 
 
@@ -116,6 +125,8 @@ func restartingManualReplayDoesNotResumeAudioRecognitionBetweenGenerations() asy
 
     #expect(viewModel.isManualReplayPlaying)
     #expect(audioRecognitionService.startCalls.count == startCallCountBeforeReplay)
+
+    viewModel.resetSession()
 }
 
 private struct ImmediateManualReplaySleeper: SleeperProtocol {

--- a/LonelyPianistAVPTests/PracticeSessionReplayGateTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionReplayGateTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+@testable import LonelyPianistAVP
+import simd
+import Testing
+
+@Test
+@MainActor
+func manualReplayBlocksGestureAdvance() async {
+    let sleeper = PendingManualReplaySleeper()
+    let viewModel = PracticeSessionViewModel(
+        pressDetectionService: ManualReplayConstantPressDetectionService(pressedNotes: [60]),
+        chordAttemptAccumulator: ManualReplayAlwaysMatchAccumulator(),
+        sleeper: sleeper,
+        noteAudioPlayer: ManualReplaySilentAudioPlayer(),
+        manualAdvanceModeProvider: { .measure }
+    )
+    viewModel.setSteps(makeReplaySteps(), tempoMap: makeReplayTempoMap(), measureSpans: makeReplayMeasures())
+    viewModel.applyKeyboardGeometry(makeReplayKeyboardGeometry(), calibration: makeReplayCalibration())
+    viewModel.startGuidingIfReady()
+    viewModel.replayCurrentUnit()
+    await Task.yield()
+
+    let before = viewModel.currentStepIndex
+    _ = viewModel.handleFingerTipPositions(["thumb": SIMD3<Float>(0, 0, 0)])
+
+    #expect(viewModel.isManualReplayPlaying)
+    #expect(viewModel.currentStepIndex == before)
+}
+
+@Test
+@MainActor
+func manualReplayBlocksAudioRecognitionAdvance() async {
+    let sleeper = PendingManualReplaySleeper()
+    let audioRecognitionService = FakePracticeAudioRecognitionService()
+    let viewModel = PracticeSessionViewModel(
+        pressDetectionService: ManualReplayNoopPressDetectionService(),
+        chordAttemptAccumulator: ManualReplayAlwaysMatchAccumulator(),
+        sleeper: sleeper,
+        noteAudioPlayer: ManualReplaySilentAudioPlayer(),
+        audioRecognitionService: audioRecognitionService,
+        manualAdvanceModeProvider: { .measure }
+    )
+    viewModel.setSteps(makeReplaySteps(), tempoMap: makeReplayTempoMap(), measureSpans: makeReplayMeasures())
+    viewModel.startGuidingIfReady()
+    await Task.yield()
+    viewModel.replayCurrentUnit()
+    await Task.yield()
+
+    let before = viewModel.currentStepIndex
+    audioRecognitionService.emitEvent(
+        DetectedNoteEvent(
+            midiNote: 60,
+            confidence: 1,
+            onsetScore: 1,
+            isOnset: true,
+            timestamp: Date(),
+            generation: viewModel.audioRecognitionGenerationForTesting,
+            source: .audio
+        )
+    )
+    await Task.yield()
+
+    #expect(viewModel.isManualReplayPlaying)
+    #expect(viewModel.currentStepIndex == before)
+}
+
+
+@Test
+@MainActor
+func completedManualReplayReturnsProgressToMeasureStart() async {
+    let viewModel = PracticeSessionViewModel(
+        pressDetectionService: ManualReplayNoopPressDetectionService(),
+        chordAttemptAccumulator: ManualReplayAlwaysMatchAccumulator(),
+        sleeper: ImmediateManualReplaySleeper(),
+        noteAudioPlayer: ManualReplaySilentAudioPlayer(),
+        manualAdvanceModeProvider: { .measure }
+    )
+    viewModel.setSteps(makeReplaySteps(), tempoMap: makeReplayTempoMap(), measureSpans: makeReplayMeasures())
+    viewModel.startGuidingIfReady()
+    viewModel.currentStepIndex = 1
+    #expect(viewModel.currentStepIndex == 1)
+
+    viewModel.replayCurrentUnit()
+    await Task.yield()
+    await Task.yield()
+    await Task.yield()
+
+    #expect(viewModel.isManualReplayPlaying == false)
+    #expect(viewModel.currentStepIndex == 0)
+}
+
+
+
+@Test
+@MainActor
+func restartingManualReplayDoesNotResumeAudioRecognitionBetweenGenerations() async {
+    let sleeper = PendingManualReplaySleeper()
+    let audioRecognitionService = FakePracticeAudioRecognitionService()
+    let viewModel = PracticeSessionViewModel(
+        pressDetectionService: ManualReplayNoopPressDetectionService(),
+        chordAttemptAccumulator: ManualReplayAlwaysMatchAccumulator(),
+        sleeper: sleeper,
+        noteAudioPlayer: ManualReplaySilentAudioPlayer(),
+        audioRecognitionService: audioRecognitionService,
+        manualAdvanceModeProvider: { .measure }
+    )
+    viewModel.setSteps(makeReplaySteps(), tempoMap: makeReplayTempoMap(), measureSpans: makeReplayMeasures())
+    viewModel.startGuidingIfReady()
+    await Task.yield()
+    let startCallCountBeforeReplay = audioRecognitionService.startCalls.count
+
+    viewModel.replayCurrentUnit()
+    await Task.yield()
+    viewModel.replayCurrentUnit()
+    await Task.yield()
+
+    #expect(viewModel.isManualReplayPlaying)
+    #expect(audioRecognitionService.startCalls.count == startCallCountBeforeReplay)
+}
+
+private struct ImmediateManualReplaySleeper: SleeperProtocol {
+    func sleep(for _: Duration) async throws {
+        await Task.yield()
+    }
+}
+private func makeReplaySteps() -> [PracticeStep] {
+    [
+        PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1)]),
+        PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 62, staff: 1)]),
+    ]
+}
+
+private func makeReplayMeasures() -> [MusicXMLMeasureSpan] {
+    [MusicXMLMeasureSpan(partID: "P1", measureNumber: 1, startTick: 0, endTick: 960)]
+}
+
+private func makeReplayTempoMap() -> MusicXMLTempoMap {
+    MusicXMLTempoMap(tempoEvents: [MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: MusicXMLEventScope(partID: "P1", staff: nil, voice: nil))])
+}
+
+private func makeReplayCalibration() -> PianoCalibration {
+    PianoCalibration(a0: SIMD3<Float>(0, 0, 0), c8: SIMD3<Float>(1, 0, 0), planeHeight: 0)
+}
+
+private func makeReplayKeyboardGeometry() -> PianoKeyboardGeometry {
+    PianoKeyboardGeometry(frame: KeyboardFrame(a0World: SIMD3<Float>(0, 0, 0), c8World: SIMD3<Float>(1, 0, 0), planeHeight: 0)!, keys: [])
+}
+
+private struct PendingManualReplaySleeper: SleeperProtocol {
+    func sleep(for _: Duration) async throws {
+        try await Task.sleep(for: .seconds(60))
+    }
+}
+
+private final class ManualReplaySilentAudioPlayer: PracticeNoteAudioPlayerProtocol {
+    func play(midiNotes _: [Int]) throws {}
+}
+
+private struct ManualReplayNoopPressDetectionService: PressDetectionServiceProtocol {
+    func detectPressedNotes(fingerTips _: [String: SIMD3<Float>], keyboardGeometry _: PianoKeyboardGeometry?, at _: Date) -> Set<Int> { [] }
+}
+
+private struct ManualReplayConstantPressDetectionService: PressDetectionServiceProtocol {
+    let pressedNotes: Set<Int>
+    func detectPressedNotes(fingerTips _: [String: SIMD3<Float>], keyboardGeometry _: PianoKeyboardGeometry?, at _: Date) -> Set<Int> { pressedNotes }
+}
+
+private final class ManualReplayAlwaysMatchAccumulator: ChordAttemptAccumulatorProtocol {
+    func register(pressedNotes _: Set<Int>, expectedNotes _: [Int], tolerance _: Int, at _: Date) -> Bool { true }
+    func reset() {}
+}

--- a/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
@@ -423,7 +423,7 @@ func advancingAutoPlaysNextStepSound() {
 @Test
 @MainActor
 func autoplaySchedulesAndAdvancesStepsUsingTempoMap() async {
-    let sleeper = ControllableSleeper()
+    let sleeper = ControllableTimingSleeper()
     let tempoMap = MusicXMLTempoMap(
         tempoEvents: [
             MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope),
@@ -440,7 +440,8 @@ func autoplaySchedulesAndAdvancesStepsUsingTempoMap() async {
     let viewModel = makePracticeSessionViewModel(
         pressDetectionService: NoopPressDetectionService(),
         chordAttemptAccumulator: NoopChordAttemptAccumulator(),
-        sleeper: sleeper
+        sleeper: sleeper,
+        timingClock: sleeper
     )
 
     viewModel.setSteps(
@@ -458,24 +459,24 @@ func autoplaySchedulesAndAdvancesStepsUsingTempoMap() async {
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
     #expect(viewModel.currentStepIndex == 1)
 
     await settleTaskQueue()
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.5)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.5)])
 
     viewModel.setAutoplayEnabled(false)
     await settleTaskQueue()
-    #expect(await sleeper.cancellationCount() == 1)
+    #expect(sleeper.cancellationCount() == 1)
 }
 
 @Test
 @MainActor
 func autoplaySchedulesPendingOnsetsInsideCurrentStep() async {
-    let sleeper = ControllableSleeper()
+    let sleeper = ControllableTimingSleeper()
     let tempoMap = MusicXMLTempoMap(
         tempoEvents: [
             MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope),
@@ -489,6 +490,7 @@ func autoplaySchedulesPendingOnsetsInsideCurrentStep() async {
         pressDetectionService: NoopPressDetectionService(),
         chordAttemptAccumulator: NoopChordAttemptAccumulator(),
         sleeper: sleeper,
+        timingClock: sleeper,
         noteAudioPlayer: nil,
         noteOutput: output
     )
@@ -558,19 +560,19 @@ func autoplaySchedulesPendingOnsetsInsideCurrentStep() async {
     await settleTaskQueue()
 
     #expect(output.recordedNoteOns.map(\.midi) == [60])
-    #expect(await sleeper.recordedDurations() == [.seconds(0.03125)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.03125)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
 
     #expect(output.recordedNoteOns.map(\.midi) == [60, 64])
-    #expect(await sleeper.recordedDurations() == [.seconds(0.03125), .seconds(0.46875)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.03125), .seconds(0.46875)])
 }
 
 @Test
 @MainActor
 func autoplayInsertsFermataHoldBeforeAdvancingWhenTimelineProvided() async {
-    let sleeper = ControllableSleeper()
+    let sleeper = ControllableTimingSleeper()
     let tempoMap = MusicXMLTempoMap(
         tempoEvents: [
             MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope),
@@ -609,7 +611,8 @@ func autoplayInsertsFermataHoldBeforeAdvancingWhenTimelineProvided() async {
     let viewModel = makePracticeSessionViewModel(
         pressDetectionService: NoopPressDetectionService(),
         chordAttemptAccumulator: NoopChordAttemptAccumulator(),
-        sleeper: sleeper
+        sleeper: sleeper,
+        timingClock: sleeper
     )
 
     viewModel.setSteps(
@@ -627,14 +630,14 @@ func autoplayInsertsFermataHoldBeforeAdvancingWhenTimelineProvided() async {
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
     #expect(viewModel.currentStepIndex == 0)
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.25)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.25)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
     #expect(viewModel.currentStepIndex == 1)
 }
@@ -642,7 +645,7 @@ func autoplayInsertsFermataHoldBeforeAdvancingWhenTimelineProvided() async {
 @Test
 @MainActor
 func autoplaySchedulesPedalChangesBetweenSteps() async {
-    let sleeper = ControllableSleeper()
+    let sleeper = ControllableTimingSleeper()
     let tempoMap = MusicXMLTempoMap(
         tempoEvents: [
             MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope),
@@ -669,7 +672,8 @@ func autoplaySchedulesPedalChangesBetweenSteps() async {
     let viewModel = makePracticeSessionViewModel(
         pressDetectionService: NoopPressDetectionService(),
         chordAttemptAccumulator: NoopChordAttemptAccumulator(),
-        sleeper: sleeper
+        sleeper: sleeper,
+        timingClock: sleeper
     )
 
     viewModel.setSteps(
@@ -686,17 +690,17 @@ func autoplaySchedulesPedalChangesBetweenSteps() async {
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
     #expect(viewModel.currentStepIndex == 0)
     #expect(viewModel.isSustainPedalDown == true)
 
     await settleTaskQueue()
-    #expect(await sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.5)])
+    #expect(sleeper.recordedDurations() == [.seconds(0.5), .seconds(0.5)])
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
     #expect(viewModel.currentStepIndex == 1)
 }
@@ -930,7 +934,7 @@ func resetCancelsPendingManualHighlightTransition() async {
 @Test
 @MainActor
 func autoplayAdvancesHighlightGuidesByTick() async {
-    let sleeper = ControllableSleeper()
+    let sleeper = ControllableTimingSleeper()
     let tempoMap = MusicXMLTempoMap(
         tempoEvents: [
             MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope),
@@ -941,7 +945,8 @@ func autoplayAdvancesHighlightGuidesByTick() async {
     let viewModel = makePracticeSessionViewModel(
         pressDetectionService: NoopPressDetectionService(),
         chordAttemptAccumulator: NoopChordAttemptAccumulator(),
-        sleeper: sleeper
+        sleeper: sleeper,
+        timingClock: sleeper
     )
 
     viewModel.setSteps(
@@ -971,9 +976,9 @@ func autoplayAdvancesHighlightGuidesByTick() async {
     await settleTaskQueue()
 
     #expect(viewModel.currentPianoHighlightGuide?.tick == 0)
-    #expect(await sleeper.callCount() >= 1)
+    #expect(sleeper.recordedDurations().isEmpty == false)
 
-    await sleeper.resumeOldestPending()
+    sleeper.resumeOldestPending()
     await settleTaskQueue()
 
     #expect(viewModel.currentPianoHighlightGuide?.tick == 120)
@@ -1297,6 +1302,7 @@ private func makePracticeSessionViewModel(
     pressDetectionService: PressDetectionServiceProtocol,
     chordAttemptAccumulator: ChordAttemptAccumulatorProtocol,
     sleeper: SleeperProtocol,
+    timingClock: PracticeTimingClockProtocol = ContinuousPracticeTimingClock(),
     noteAudioPlayer: PracticeNoteAudioPlayerProtocol? = nil,
     noteOutput: PracticeMIDINoteOutputProtocol? = nil
 ) -> PracticeSessionViewModel {
@@ -1304,6 +1310,7 @@ private func makePracticeSessionViewModel(
         pressDetectionService: pressDetectionService,
         chordAttemptAccumulator: chordAttemptAccumulator,
         sleeper: sleeper,
+        timingClock: timingClock,
         noteAudioPlayer: noteAudioPlayer,
         noteOutput: noteOutput ?? CapturingMIDINoteOutput()
     )
@@ -1511,6 +1518,61 @@ private actor ControllableSleeper: SleeperProtocol {
             let continuation = continuationsByID.removeValue(forKey: requestID)
         else {
             return
+        }
+        continuation.resume()
+    }
+
+    private func handleCancellation(for requestID: UUID) {
+        cancelledRequestIDs.insert(requestID)
+        if let continuation = continuationsByID.removeValue(forKey: requestID) {
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+}
+
+private final class ControllableTimingSleeper: SleeperProtocol, PracticeTimingClockProtocol, @unchecked Sendable {
+    private var requests: [UUID] = []
+    private var durationsByID: [UUID: Duration] = [:]
+    private var continuationsByID: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var cancelledRequestIDs: Set<UUID> = []
+    private var elapsedSeconds: TimeInterval = 0
+
+    func nowSeconds() -> TimeInterval {
+        elapsedSeconds
+    }
+
+    func sleep(for duration: Duration) async throws {
+        let requestID = UUID()
+        requests.append(requestID)
+        durationsByID[requestID] = duration
+
+        try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                continuationsByID[requestID] = continuation
+            }
+        }, onCancel: {
+            self.handleCancellation(for: requestID)
+        })
+    }
+
+    func recordedDurations() -> [Duration] {
+        requests.compactMap { durationsByID[$0] }
+    }
+
+    func cancellationCount() -> Int {
+        cancelledRequestIDs.count
+    }
+
+    func resumeOldestPending() {
+        guard
+            let requestID = requests.first(where: { continuationsByID[$0] != nil }),
+            let continuation = continuationsByID.removeValue(forKey: requestID)
+        else {
+            return
+        }
+        if let duration = durationsByID[requestID] {
+            let components = duration.components
+            elapsedSeconds += TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
         }
         continuation.resume()
     }

--- a/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
+++ b/LonelyPianistAVPTests/PracticeSessionViewModelTests.swift
@@ -170,7 +170,9 @@ func markCorrectSchedulesFeedbackResetWithExpectedDuration() async {
 
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     viewModel.applyKeyboardGeometry(
         makeDummyKeyboardGeometry(),
@@ -200,7 +202,9 @@ func secondFeedbackCancelsPreviousResetTaskDeterministically() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 1, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     viewModel.applyKeyboardGeometry(
         makeDummyKeyboardGeometry(),
@@ -234,7 +238,9 @@ func feedbackResetsToNoneAfterSleeperResumes() async {
 
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     viewModel.applyKeyboardGeometry(
         makeDummyKeyboardGeometry(),
@@ -262,7 +268,9 @@ func stepsOnlyGuidingStartsWithoutCalibration() {
 
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
 
     #expect(viewModel.currentStep != nil)
@@ -281,7 +289,9 @@ func skipAdvancesAndCompletesInStepsOnlyMode() {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 1, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
 
     viewModel.skip()
@@ -303,7 +313,9 @@ func handleFingerTipPositionsIsNoopWithoutKeyboardGeometry() {
 
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
 
     let detected = viewModel.handleFingerTipPositions(["dummy": .zero])
@@ -324,7 +336,9 @@ func applyingCalibrationDoesNotResetProgress() {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 1, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     viewModel.skip()
     #expect(viewModel.currentStepIndex == 1)
@@ -354,7 +368,9 @@ func guidingStartAutoPlaysCurrentStepSound() {
             PracticeStepNote(midiNote: 60, staff: nil),
             PracticeStepNote(midiNote: 64, staff: nil),
         ]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
 
     #expect(audioPlayer.recordedPlays == [[60, 64]])
@@ -372,7 +388,9 @@ func guidingStartRecordsAudioErrorWhenAudioPlayerThrows() async {
 
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     await settleTaskQueue()
 
@@ -393,7 +411,9 @@ func advancingAutoPlaysNextStepSound() {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 1, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.startGuidingIfReady()
     viewModel.skip()
 
@@ -746,7 +766,9 @@ func autoplayDoesNotAdvanceOnMatch() async {
     viewModel.setSteps([
         PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: nil)]),
         PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 62, staff: nil)]),
-    ])
+    ],
+        tempoMap: MusicXMLTempoMap(tempoEvents: [])
+    )
     viewModel.setAutoplayEnabled(true)
     viewModel.applyKeyboardGeometry(
         makeDummyKeyboardGeometry(),
@@ -777,7 +799,7 @@ func highlightGuideStartsAtFirstTriggerAfterStartGuiding() async {
             PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1, voice: 1)]),
             PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 62, staff: 1, voice: 1)]),
         ],
-        tempoMap: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: []),
         pedalTimeline: nil,
         noteSpans: [],
         highlightGuides: [
@@ -808,7 +830,7 @@ func resetSessionClearsCurrentHighlightGuide() async {
         [
             PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1, voice: 1)]),
         ],
-        tempoMap: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: []),
         pedalTimeline: nil,
         noteSpans: [],
         highlightGuides: [
@@ -841,7 +863,7 @@ func manualAdvanceShowsReleaseOrGapGuideBeforeNextTrigger() async {
             PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1, voice: 1)]),
             PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 62, staff: 1, voice: 1)]),
         ],
-        tempoMap: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: []),
         pedalTimeline: nil,
         noteSpans: [],
         highlightGuides: [
@@ -882,7 +904,7 @@ func resetCancelsPendingManualHighlightTransition() async {
             PracticeStep(tick: 0, notes: [PracticeStepNote(midiNote: 60, staff: 1, voice: 1)]),
             PracticeStep(tick: 480, notes: [PracticeStepNote(midiNote: 62, staff: 1, voice: 1)]),
         ],
-        tempoMap: nil,
+        tempoMap: MusicXMLTempoMap(tempoEvents: []),
         pedalTimeline: nil,
         noteSpans: [],
         highlightGuides: [


### PR DESCRIPTION
## 背景

本 PR 实现 `manual-advance-measure` plan 中定义的手动前进增强能力：在练习模式中支持按 step 或按 measure 前进，并为 measure 模式补齐小节级跳转、重播本节、replay gate 与相关测试。

## 主要变更

### 设置与数据模型

- 新增 `ManualAdvanceMode`，支持：
  - `step`
  - `measure`
- 设置页新增手动前进模式选择项，默认保持 `step`，兼容现有行为。
- 将 `tempoMap` 改为手动练习路径的必需参数，避免运行时 fallback 或 silent nil。
- 恢复并更新 `AppModel.swift`，确保导入乐谱后会把：
  - steps
  - tempo map
  - measure spans  
  正确传递到 `PracticeSessionViewModel`。

### 手动前进策略

- 新增手动前进策略协议。
- 新增：
  - `StepManualAdvanceStrategy`
  - `MeasureManualAdvanceStrategy`
- `step` 模式保持原有“下一步”行为。
- `measure` 模式支持跳转到下一小节开头。
- measure span 缺失时保留安全 fallback，避免破坏既有 step 行为。

### UI 行为

- 根据手动前进模式动态切换按钮文案：
  - step 模式：`下一步` / `播放琴声`
  - measure 模式：`下一节` / `重播本节`
- 重播期间禁用不应触发的交互，避免状态竞争。
- 到达末尾时按钮禁用逻辑保持与现有练习状态一致。

### 重播本节

- measure 模式下支持“重播本节” mini-autoplay。
- 使用 `tempoMap.durationSeconds` 按实际节奏排程 step 播放。
- replay 自然结束后恢复到当前小节开头。
- 支持 replay cancel，取消后恢复正常识别/交互状态。
- 修复重复点击 replay 时旧 replay cancel 短暂恢复音频识别的竞态问题。

### Gate 与稳定性

- replay 期间 gate 掉：
  - 手势触发的自动前进
  - 麦克风/音频事件触发的自动前进
- 修正 replay gate 测试中硬编码 `generation: 0` 导致测试未真正覆盖 gate 的问题。
- 增加重复 replay、replay 完成恢复位置等边界测试。

## 测试

新增/更新测试覆盖：

- `ManualAdvanceStrategyTests`
  - step 模式保持逐 step 前进
  - measure 模式跳转到下一小节开头
  - 小节 span 缺失时安全 fallback
- `PracticeSessionReplayGateTests`
  - replay 期间手势输入不会推进
  - replay 期间音频输入不会推进
  - replay 完成后恢复到小节开头
  - 重复 replay 不会短暂恢复音频识别
- AppModel 传播测试
  - 验证导入乐谱后的 measure spans 能进入 `PracticeSessionViewModel`
  - 验证 measure 模式可基于导入数据跳到下一小节

## 验证

已在当前环境完成静态验证：

- 确认 `AppModel.swift` 已恢复。
- 确认 `setSteps` / `setImportedSteps` 的 `tempoMap` 参数已改为必需。
- 确认调用点均显式传入 `MusicXMLTempoMap`。
- 确认无 `tempoMap: nil` / optional tempoMap fallback 残留。
- 确认 replay gate 测试不再硬编码 `generation: 0`。
- 确认修改 Swift 文件括号平衡。

当前执行环境没有 `rtk` / `xcodebuild` / visionOS Simulator，因此未能在容器中执行完整 Apple build/test。合并前需要在 macOS + Xcode 环境补跑：

```bash
rtk xcodebuild test \
  -scheme LonelyPianistAVP \
  -destination 'platform=visionOS Simulator,name=Apple Vision Pro'