### PR TITLE
Disable audio recognition on visionOS Simulator

### DIFF
--- a/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/PracticeSessionViewModel.swift
@@ -122,12 +122,17 @@ final class PracticeSessionViewModel {
 
     convenience init() {
         let playbackService = AVAudioSequencerPracticePlaybackService(soundFontResourceName: "SalC5Light2")
+#if targetEnvironment(simulator)
+        let audioRecognitionService: PracticeAudioRecognitionServiceProtocol? = nil
+#else
+        let audioRecognitionService: PracticeAudioRecognitionServiceProtocol? = PracticeAudioRecognitionService()
+#endif
         self.init(
             pressDetectionService: PressDetectionService(),
             chordAttemptAccumulator: ChordAttemptAccumulator(),
             sleeper: TaskSleeper(),
             sequencerPlaybackService: playbackService,
-            audioRecognitionService: PracticeAudioRecognitionService()
+            audioRecognitionService: audioRecognitionService
         )
     }
 


### PR DESCRIPTION
Simulator often reports an invalid microphone input format (no real input route), which triggers the "音频不可用" alert repeatedly. This change disables audio recognition injection when built for the Simulator; real devices are unchanged.