### PR TITLE
Pulse key highlight on repeated notes

### DIFF
--- a/LonelyPianistAVP/Views/Immersive/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Views/Immersive/PianoGuideOverlayController.swift
@@ -22,6 +22,7 @@ final class PianoGuideOverlayController {
         highlightGuide: PianoHighlightGuide?,
         keyboardGeometry: PianoKeyboardGeometry?,
         feedbackState: PracticeSessionViewModel.VisualFeedbackState,
+        isAutoplayEnabled: Bool,
         content: RealityViewContent
     ) {
         if hasAttachedRoot == false {
@@ -37,7 +38,10 @@ final class PianoGuideOverlayController {
 
         keyboardRootEntity.transform = Transform(matrix: keyboardGeometry.frame.worldFromKeyboard)
 
-        if let highlightGuide, highlightGuide.triggeredNotes.isEmpty == false {
+        if isAutoplayEnabled == false {
+            lastTriggerTimestampByMIDINote.removeAll()
+            lastTriggerGuideIDByMIDINote.removeAll()
+        } else if let highlightGuide, highlightGuide.triggeredNotes.isEmpty == false {
             let now = ProcessInfo.processInfo.systemUptime
             for note in highlightGuide.triggeredNotes {
                 if lastTriggerGuideIDByMIDINote[note.midiNote] != highlightGuide.id {

--- a/LonelyPianistAVP/Views/Immersive/PianoGuideOverlayController.swift
+++ b/LonelyPianistAVP/Views/Immersive/PianoGuideOverlayController.swift
@@ -9,8 +9,14 @@ final class PianoGuideOverlayController {
     private var hasAttachedRoot = false
     private var activeBeamEntitiesByMIDINote: [Int: ModelEntity] = [:]
     private var lastGuideIDByMIDINote: [Int: Int] = [:]
+    private var lastTriggerTimestampByMIDINote: [Int: TimeInterval] = [:]
+    private var lastTriggerGuideIDByMIDINote: [Int: Int] = [:]
     private var didAttemptAtlasTextureLoad = false
     private var atlasTexture: TextureResource?
+
+    private let pulseDurationSeconds: TimeInterval = 0.22
+    private let pulseScaleBoost: Float = 0.22
+    private let pulseAlphaBoost: Float = 0.55
 
     func updateHighlights(
         highlightGuide: PianoHighlightGuide?,
@@ -31,6 +37,16 @@ final class PianoGuideOverlayController {
 
         keyboardRootEntity.transform = Transform(matrix: keyboardGeometry.frame.worldFromKeyboard)
 
+        if let highlightGuide, highlightGuide.triggeredNotes.isEmpty == false {
+            let now = ProcessInfo.processInfo.systemUptime
+            for note in highlightGuide.triggeredNotes {
+                if lastTriggerGuideIDByMIDINote[note.midiNote] != highlightGuide.id {
+                    lastTriggerGuideIDByMIDINote[note.midiNote] = highlightGuide.id
+                    lastTriggerTimestampByMIDINote[note.midiNote] = now
+                }
+            }
+        }
+
         let descriptors = PianoGuideBeamDescriptor.makeDescriptors(
             highlightGuide: highlightGuide,
             keyboardGeometry: keyboardGeometry,
@@ -42,12 +58,15 @@ final class PianoGuideOverlayController {
         }
 
         let desiredNotes = Set(descriptors.map(\.midiNote))
+        let now = ProcessInfo.processInfo.systemUptime
 
         for (midiNote, beam) in activeBeamEntitiesByMIDINote {
             if desiredNotes.contains(midiNote) == false {
                 beam.removeFromParent()
                 activeBeamEntitiesByMIDINote[midiNote] = nil
                 lastGuideIDByMIDINote[midiNote] = nil
+                lastTriggerTimestampByMIDINote[midiNote] = nil
+                lastTriggerGuideIDByMIDINote[midiNote] = nil
             }
         }
 
@@ -65,13 +84,27 @@ final class PianoGuideOverlayController {
                 keyboardRootEntity.addChild(beam)
             }
 
-            beam.model?.materials = [beamMaterial(for: descriptor)]
-            beam.scale = descriptor.sizeLocal
+            let pulse = pulseIntensity(for: descriptor.midiNote, now: now)
+            beam.model?.materials = [beamMaterial(for: descriptor, pulse: pulse)]
+            var scale = descriptor.sizeLocal
+            let boost = max(0, min(1, pulse)) * pulseScaleBoost
+            scale.x *= (1 + boost)
+            scale.z *= (1 + boost)
+            beam.scale = scale
             beam.position = descriptor.positionLocal
         }
     }
 
-    private func beamMaterial(for descriptor: PianoGuideBeamDescriptor) -> UnlitMaterial {
+    private func pulseIntensity(for midiNote: Int, now: TimeInterval) -> Float {
+        guard let triggeredAt = lastTriggerTimestampByMIDINote[midiNote] else { return 0 }
+        let elapsed = now - triggeredAt
+        guard elapsed >= 0, elapsed < pulseDurationSeconds else { return 0 }
+        let t = Float(elapsed / pulseDurationSeconds)
+        let remaining = 1 - t
+        return remaining * remaining
+    }
+
+    private func beamMaterial(for descriptor: PianoGuideBeamDescriptor, pulse: Float) -> UnlitMaterial {
         let tintColor: UIColor = switch descriptor.baseColor {
             case .guide:
                 AVPOverlayPalette.feedbackNoneColor
@@ -80,7 +113,8 @@ final class PianoGuideOverlayController {
             case .wrong:
                 AVPOverlayPalette.feedbackWrongColor
         }
-        let tinted = tintColor.withAlphaComponent(CGFloat(descriptor.alpha))
+        let pulsedAlpha = max(0, min(1, descriptor.alpha + max(0, min(1, pulse)) * pulseAlphaBoost))
+        let tinted = tintColor.withAlphaComponent(CGFloat(pulsedAlpha))
         let texture = loadAtlasTextureIfNeeded()
 
         var material = UnlitMaterial()
@@ -98,6 +132,8 @@ final class PianoGuideOverlayController {
         }
         activeBeamEntitiesByMIDINote.removeAll()
         lastGuideIDByMIDINote.removeAll()
+        lastTriggerTimestampByMIDINote.removeAll()
+        lastTriggerGuideIDByMIDINote.removeAll()
     }
 
     private func loadAtlasTextureIfNeeded() -> TextureResource? {

--- a/LonelyPianistAVP/Views/ImmersiveView.swift
+++ b/LonelyPianistAVP/Views/ImmersiveView.swift
@@ -37,6 +37,7 @@ struct ImmersiveView: View {
                 highlightGuide: viewModel.practiceSessionViewModel.currentPianoHighlightGuide,
                 keyboardGeometry: viewModel.practiceSessionViewModel.keyboardGeometry,
                 feedbackState: viewModel.practiceSessionViewModel.feedbackState,
+                isAutoplayEnabled: viewModel.practiceSessionViewModel.autoplayState == .playing,
                 content: content
             )
         } update: { content in
@@ -57,6 +58,7 @@ struct ImmersiveView: View {
                 highlightGuide: viewModel.practiceSessionViewModel.currentPianoHighlightGuide,
                 keyboardGeometry: viewModel.practiceSessionViewModel.keyboardGeometry,
                 feedbackState: viewModel.practiceSessionViewModel.feedbackState,
+                isAutoplayEnabled: viewModel.practiceSessionViewModel.autoplayState == .playing,
                 content: content
             )
         }

--- a/LonelyPianistAVP/Views/PianoKeyboard88View.swift
+++ b/LonelyPianistAVP/Views/PianoKeyboard88View.swift
@@ -7,17 +7,20 @@ struct PianoKeyboard88View: View {
 
     let highlightedMIDINotes: Set<Int>
     let highlightOccurrenceID: Int?
+    let triggeredMIDINotes: Set<Int>
     let fingeringByMIDINote: [Int: String]
     let highlightColorByMIDINote: [Int: Color]
 
     init(
         highlightedMIDINotes: Set<Int>,
         highlightOccurrenceID: Int? = nil,
+        triggeredMIDINotes: Set<Int> = [],
         fingeringByMIDINote: [Int: String] = [:],
         highlightColorByMIDINote: [Int: Color] = [:]
     ) {
         self.highlightedMIDINotes = highlightedMIDINotes
         self.highlightOccurrenceID = highlightOccurrenceID
+        self.triggeredMIDINotes = triggeredMIDINotes
         self.fingeringByMIDINote = fingeringByMIDINote
         self.highlightColorByMIDINote = highlightColorByMIDINote
     }
@@ -37,6 +40,11 @@ struct PianoKeyboard88View: View {
                         .overlay {
                             Rectangle()
                                 .stroke(.black.opacity(0.22), lineWidth: 0.6)
+                        }
+                        .overlay {
+                            if triggeredMIDINotes.contains(key.midiNote) {
+                                KeyTriggerPulseOverlay(isBlackKey: false)
+                            }
                         }
                         .overlay(alignment: .bottom) {
                             if isHighlighted,
@@ -65,6 +73,11 @@ struct PianoKeyboard88View: View {
                         .overlay {
                             Rectangle()
                                 .stroke(.white.opacity(0.28), lineWidth: 0.5)
+                        }
+                        .overlay {
+                            if triggeredMIDINotes.contains(key.midiNote) {
+                                KeyTriggerPulseOverlay(isBlackKey: true)
+                            }
                         }
                         .overlay(alignment: .bottom) {
                             if isHighlighted,
@@ -169,6 +182,25 @@ struct PianoKeyboard88View: View {
     ) -> String {
         let prefix = isBlackKey ? "black" : "white"
         return "\(prefix)-\(midiNote)-\(highlightOccurrenceID ?? 0)-\(isHighlighted)"
+    }
+}
+
+private struct KeyTriggerPulseOverlay: View {
+    let isBlackKey: Bool
+
+    @State private var opacity: Double = 0.0
+
+    var body: some View {
+        Rectangle()
+            .fill(isBlackKey ? Color.orange : Color.yellow)
+            .opacity(opacity)
+            .allowsHitTesting(false)
+            .onAppear {
+                opacity = isBlackKey ? 0.95 : 0.75
+                withAnimation(.easeOut(duration: 0.22)) {
+                    opacity = 0.0
+                }
+            }
     }
 }
 

--- a/LonelyPianistAVP/Views/PracticeStepView.swift
+++ b/LonelyPianistAVP/Views/PracticeStepView.swift
@@ -22,6 +22,7 @@ struct PracticeStepView: View {
         PianoKeyboard88View(
             highlightedMIDINotes: highlightedMIDINotes,
             highlightOccurrenceID: viewModel.practiceSessionViewModel.currentPianoHighlightGuide?.id,
+            triggeredMIDINotes: triggeredMIDINotes,
             fingeringByMIDINote: fingeringByMIDINote
         )
         .aspectRatio(PianoKeyboard88View.aspectRatio, contentMode: .fit)
@@ -180,6 +181,12 @@ struct PracticeStepView: View {
     private var fingeringByMIDINote: [Int: String] {
         guard isAutoplayEnabled else { return [:] }
         return viewModel.practiceSessionViewModel.currentPianoHighlightGuide?.fingeringByMIDINote ?? [:]
+    }
+
+    private var triggeredMIDINotes: Set<Int> {
+        guard isAutoplayEnabled else { return [] }
+        let notes = viewModel.practiceSessionViewModel.currentPianoHighlightGuide?.triggeredNotes ?? []
+        return Set(notes.map(\.midiNote))
     }
 
     private var localizationPopover: some View {


### PR DESCRIPTION
按你唯一真需求（连续 C4 必须能看出是第二次触发），我已经先把 2D 做成“每次 trigger 都pulse 一下”：

- LonelyPianistAVP/Views/PracticeStepView.swift:22：自动播放时把currentPianoHighlightGuide.triggeredNotes 的 MIDI 集合传给 2D 键盘
- LonelyPianistAVP/Views/PianoKeyboard88View.swift:1：新增 triggeredMIDINotes，对触发到的键叠一层短促渐隐的 KeyTriggerPulseOverlay

现在在自动播放里 C4 → C4 会在第二次 C4 触发时明显闪一下（不需要强行“断开高亮”）。


3D AR钢琴高亮的自动播放也实现啦！