### PR TITLE
AVP练习支持外部MIDI输出

### DIFF
--- a/LonelyPianistAVP/Services/Audio/AudioOutputVolumeSettings.swift
+++ b/LonelyPianistAVP/Services/Audio/AudioOutputVolumeSettings.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum AudioOutputVolumeSettings {
+  static let userDefaultsKey = "audioOutputVolume"
+  static let defaultValue: Float = 1.0
+
+  static func readAudioOutputVolume(from userDefaults: UserDefaults = .standard) -> Float {
+    guard let number = userDefaults.object(forKey: Self.userDefaultsKey) as? NSNumber else {
+      return Self.defaultValue
+    }
+
+    let value = number.floatValue
+    guard value.isFinite else { return Self.defaultValue }
+    return min(max(value, 0.0), 1.0)
+  }
+}

--- a/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+@MainActor
+final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServiceProtocol {
+    private let outputService: CoreMIDIOutputService
+    private let destinationUniqueID: Int32
+
+    private let velocity: UInt8
+    private let channel: UInt8
+
+    private var loadedSequence: PracticeSequencerSequence?
+    private var scheduler: MIDIEventScheduler?
+
+    private var playingOneShotNotes: Set<UInt8> = []
+    private var oneShotStopTask: Task<Void, Never>?
+    private var liveNotes: Set<UInt8> = []
+
+    private var lastKnownSeconds: TimeInterval = 0
+    private var playbackStartedAtUptimeSeconds: TimeInterval?
+    private var playbackStartSeconds: TimeInterval = 0
+
+    init(
+        destinationUniqueID: Int32,
+        outputService: CoreMIDIOutputService = CoreMIDIOutputService(),
+        velocity: UInt8 = 96,
+        channel: UInt8 = 0
+    ) {
+        self.destinationUniqueID = destinationUniqueID
+        self.outputService = outputService
+        self.velocity = velocity
+        self.channel = channel
+    }
+
+    func warmUp() throws {
+        try ensureReady()
+    }
+
+    func stop() {
+        oneShotStopTask?.cancel()
+        oneShotStopTask = nil
+
+        if let playbackStartedAtUptimeSeconds {
+            lastKnownSeconds = playbackStartSeconds + max(0, ProcessInfo.processInfo.systemUptime - playbackStartedAtUptimeSeconds)
+        }
+        playbackStartedAtUptimeSeconds = nil
+
+        Task { [scheduler] in
+            await scheduler?.stop()
+        }
+        scheduler = nil
+
+        stopAllLiveNotes()
+        stopOneShotNotes()
+
+        sendAllNotesOffBestEffort()
+    }
+
+    func load(sequence: PracticeSequencerSequence) throws {
+        try ensureReady()
+        stop()
+        loadedSequence = sequence
+        lastKnownSeconds = 0
+    }
+
+    func play(fromSeconds start: TimeInterval) throws {
+        try ensureReady()
+        guard let sequence = loadedSequence else { return }
+
+        stop()
+
+        let startSeconds = max(0, start)
+        lastKnownSeconds = startSeconds
+        playbackStartSeconds = startSeconds
+        playbackStartedAtUptimeSeconds = ProcessInfo.processInfo.systemUptime
+
+        let scheduler = MIDIEventScheduler(
+            outputService: outputService,
+            destinationUniqueID: destinationUniqueID,
+            channel: channel
+        )
+        self.scheduler = scheduler
+
+        let events = sequence.events
+        Task.detached(priority: .userInitiated) {
+            await scheduler.play(events: events, fromSeconds: startSeconds)
+        }
+    }
+
+    func currentSeconds() -> TimeInterval {
+        guard let playbackStartedAtUptimeSeconds else { return lastKnownSeconds }
+        let now = ProcessInfo.processInfo.systemUptime
+        let seconds = playbackStartSeconds + max(0, now - playbackStartedAtUptimeSeconds)
+        if let loadedSequence {
+            return min(seconds, loadedSequence.durationSeconds)
+        }
+        return seconds
+    }
+
+    func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws {
+        let notes = midiNotes.compactMap { UInt8(exactly: $0) }
+        guard notes.isEmpty == false else { return }
+
+        try ensureReady()
+
+        oneShotStopTask?.cancel()
+        oneShotStopTask = nil
+
+        stopOneShotNotes()
+
+        for note in notes {
+            try? outputService.sendNoteOn(
+                note: note,
+                velocity: velocity,
+                channel: channel,
+                destinationUniqueID: destinationUniqueID
+            )
+            playingOneShotNotes.insert(note)
+        }
+
+        oneShotStopTask = Task.detached(priority: .userInitiated) { [weak self] in
+            try? await Task.sleep(for: .seconds(max(0, durationSeconds)))
+            guard Task.isCancelled == false else { return }
+            await MainActor.run { [weak self] in
+                self?.stopOneShotNotes()
+            }
+        }
+    }
+
+    func startLiveNotes(midiNotes: Set<Int>) throws {
+        try ensureReady()
+        for midiNote in midiNotes {
+            guard let note = UInt8(exactly: midiNote), liveNotes.contains(note) == false else { continue }
+            try? outputService.sendNoteOn(
+                note: note,
+                velocity: velocity,
+                channel: channel,
+                destinationUniqueID: destinationUniqueID
+            )
+            liveNotes.insert(note)
+        }
+    }
+
+    func stopLiveNotes(midiNotes: Set<Int>) {
+        for midiNote in midiNotes {
+            guard let note = UInt8(exactly: midiNote), liveNotes.contains(note) else { continue }
+            try? outputService.sendNoteOff(note: note, channel: channel, destinationUniqueID: destinationUniqueID)
+            liveNotes.remove(note)
+        }
+    }
+
+    func stopAllLiveNotes() {
+        for note in liveNotes {
+            try? outputService.sendNoteOff(note: note, channel: channel, destinationUniqueID: destinationUniqueID)
+        }
+        liveNotes.removeAll()
+    }
+
+    private func stopOneShotNotes() {
+        for note in playingOneShotNotes {
+            try? outputService.sendNoteOff(note: note, channel: channel, destinationUniqueID: destinationUniqueID)
+        }
+        playingOneShotNotes.removeAll()
+    }
+
+    private func sendAllNotesOffBestEffort() {
+        try? outputService.sendAllNotesOff(channel: channel, destinationUniqueID: destinationUniqueID)
+        try? outputService.sendAllSoundOff(channel: channel, destinationUniqueID: destinationUniqueID)
+    }
+
+    private func ensureReady() throws {
+        try outputService.start()
+    }
+}
+
+actor MIDIEventScheduler {
+    private let outputService: CoreMIDIOutputService
+    private let destinationUniqueID: Int32
+    private let channel: UInt8
+
+    private var playTask: Task<Void, Never>?
+    private var playStartedAtUptimeSeconds: TimeInterval?
+    private var playStartSeconds: TimeInterval = 0
+    private(set) var currentSeconds: TimeInterval = 0
+
+    init(outputService: CoreMIDIOutputService, destinationUniqueID: Int32, channel: UInt8) {
+        self.outputService = outputService
+        self.destinationUniqueID = destinationUniqueID
+        self.channel = channel
+    }
+
+    func play(events: [PracticeSequencerMIDIEvent], fromSeconds startSeconds: TimeInterval) {
+        stopInternal()
+
+        playStartSeconds = startSeconds
+        playStartedAtUptimeSeconds = ProcessInfo.processInfo.systemUptime
+        currentSeconds = startSeconds
+
+        let eventsToPlay = events.filter { $0.timeSeconds >= startSeconds }
+        playTask = Task.detached(priority: .userInitiated) { [outputService, destinationUniqueID, channel] in
+            let startedAt = ProcessInfo.processInfo.systemUptime
+            var index = 0
+
+            while index < eventsToPlay.count, Task.isCancelled == false {
+                let event = eventsToPlay[index]
+                let targetUptime = startedAt + max(0, event.timeSeconds - startSeconds)
+                let now = ProcessInfo.processInfo.systemUptime
+                let wait = max(0, targetUptime - now)
+                if wait > 0 {
+                    try? await Task.sleep(for: .seconds(wait))
+                    guard Task.isCancelled == false else { break }
+                }
+
+                do {
+                    try Self.send(event: event, outputService: outputService, destinationUniqueID: destinationUniqueID, channel: channel)
+                } catch {
+                    // best-effort: ignore individual send failures
+                }
+                index += 1
+            }
+        }
+    }
+
+    func stop() {
+        stopInternal()
+    }
+
+    func setCurrentSeconds(_ seconds: TimeInterval) {
+        currentSeconds = seconds
+    }
+
+    private func stopInternal() {
+        playTask?.cancel()
+        playTask = nil
+        playStartedAtUptimeSeconds = nil
+    }
+
+    private static func send(
+        event: PracticeSequencerMIDIEvent,
+        outputService: CoreMIDIOutputService,
+        destinationUniqueID: Int32,
+        channel: UInt8
+    ) throws {
+        switch event.kind {
+        case let .noteOn(midi, velocity):
+            guard let note = UInt8(exactly: midi) else { return }
+            try outputService.sendNoteOn(note: note, velocity: velocity, channel: channel, destinationUniqueID: destinationUniqueID)
+        case let .noteOff(midi):
+            guard let note = UInt8(exactly: midi) else { return }
+            try outputService.sendNoteOff(note: note, channel: channel, destinationUniqueID: destinationUniqueID)
+        case let .controlChange(controller, value):
+            try outputService.sendControlChange(controller: controller, value: value, channel: channel, destinationUniqueID: destinationUniqueID)
+        case let .programChange(program):
+            try outputService.sendProgramChange(program: program, channel: channel, destinationUniqueID: destinationUniqueID)
+        case let .pitchBend(value):
+            let lsb = UInt8(value & 0x7F)
+            let msb = UInt8((value >> 7) & 0x7F)
+            let status: UInt8 = 0xE0 | (channel & 0x0F)
+            try outputService.sendMIDI1Bytes([status, lsb, msb], destinationUniqueID: destinationUniqueID)
+        case let .channelPressure(value):
+            let status: UInt8 = 0xD0 | (channel & 0x0F)
+            try outputService.sendMIDI1Bytes([status, value], destinationUniqueID: destinationUniqueID)
+        case let .polyPressure(midi, value):
+            guard let note = UInt8(exactly: midi) else { return }
+            let status: UInt8 = 0xA0 | (channel & 0x0F)
+            try outputService.sendMIDI1Bytes([status, note, value], destinationUniqueID: destinationUniqueID)
+        }
+    }
+}

--- a/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServiceProtocol {
-    private let outputService: CoreMIDIOutputService
+    private let outputService: any MIDIOutputSendingProtocol
     private let destinationUniqueID: Int32
 
     private let velocity: UInt8
@@ -21,7 +21,7 @@ final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServicePro
 
     init(
         destinationUniqueID: Int32,
-        outputService: CoreMIDIOutputService = CoreMIDIOutputService(),
+        outputService: any MIDIOutputSendingProtocol = CoreMIDIOutputService(),
         velocity: UInt8 = 96,
         channel: UInt8 = 0
     ) {
@@ -173,7 +173,7 @@ final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServicePro
 }
 
 actor MIDIEventScheduler {
-    private let outputService: CoreMIDIOutputService
+    private let outputService: any MIDIOutputSendingProtocol
     private let destinationUniqueID: Int32
     private let channel: UInt8
 
@@ -182,7 +182,7 @@ actor MIDIEventScheduler {
     private var playStartSeconds: TimeInterval = 0
     private(set) var currentSeconds: TimeInterval = 0
 
-    init(outputService: CoreMIDIOutputService, destinationUniqueID: Int32, channel: UInt8) {
+    init(outputService: any MIDIOutputSendingProtocol, destinationUniqueID: Int32, channel: UInt8) {
         self.outputService = outputService
         self.destinationUniqueID = destinationUniqueID
         self.channel = channel
@@ -236,7 +236,7 @@ actor MIDIEventScheduler {
 
     private static func send(
         event: PracticeSequencerMIDIEvent,
-        outputService: CoreMIDIOutputService,
+        outputService: any MIDIOutputSendingProtocol,
         destinationUniqueID: Int32,
         channel: UInt8
     ) throws {

--- a/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
@@ -178,9 +178,6 @@ actor MIDIEventScheduler {
     private let channel: UInt8
 
     private var playTask: Task<Void, Never>?
-    private var playStartedAtUptimeSeconds: TimeInterval?
-    private var playStartSeconds: TimeInterval = 0
-    private(set) var currentSeconds: TimeInterval = 0
 
     init(outputService: any MIDIOutputSendingProtocol, destinationUniqueID: Int32, channel: UInt8) {
         self.outputService = outputService
@@ -190,10 +187,6 @@ actor MIDIEventScheduler {
 
     func play(events: [PracticeSequencerMIDIEvent], fromSeconds startSeconds: TimeInterval) {
         stopInternal()
-
-        playStartSeconds = startSeconds
-        playStartedAtUptimeSeconds = ProcessInfo.processInfo.systemUptime
-        currentSeconds = startSeconds
 
         let eventsToPlay = events.filter { $0.timeSeconds >= startSeconds }
         playTask = Task.detached(priority: .userInitiated) { [outputService, destinationUniqueID, channel] in
@@ -224,14 +217,9 @@ actor MIDIEventScheduler {
         stopInternal()
     }
 
-    func setCurrentSeconds(_ seconds: TimeInterval) {
-        currentSeconds = seconds
-    }
-
     private func stopInternal() {
         playTask?.cancel()
         playTask = nil
-        playStartedAtUptimeSeconds = nil
     }
 
     private static func send(

--- a/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
@@ -96,36 +96,6 @@ final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServicePro
         return seconds
     }
 
-    func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws {
-        let notes = midiNotes.compactMap { UInt8(exactly: $0) }
-        guard notes.isEmpty == false else { return }
-
-        try ensureReady()
-
-        oneShotStopTask?.cancel()
-        oneShotStopTask = nil
-
-        stopOneShotNotes()
-
-        for note in notes {
-            try? outputService.sendNoteOn(
-                note: note,
-                velocity: velocity,
-                channel: channel,
-                destinationUniqueID: destinationUniqueID
-            )
-            playingOneShotNotes.insert(note)
-        }
-
-        oneShotStopTask = Task.detached(priority: .userInitiated) { [weak self] in
-            try? await Task.sleep(for: .seconds(max(0, durationSeconds)))
-            guard Task.isCancelled == false else { return }
-            await MainActor.run { [weak self] in
-                self?.stopOneShotNotes()
-            }
-        }
-    }
-
     func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
         let notes = noteOns.compactMap { noteOn -> (note: UInt8, velocity: UInt8)? in
             guard let note = UInt8(exactly: noteOn.midiNote) else { return nil }

--- a/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/CoreMIDIPracticePlaybackService.swift
@@ -126,6 +126,39 @@ final class CoreMIDIPracticePlaybackService: PracticeSequencerPlaybackServicePro
         }
     }
 
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
+        let notes = noteOns.compactMap { noteOn -> (note: UInt8, velocity: UInt8)? in
+            guard let note = UInt8(exactly: noteOn.midiNote) else { return nil }
+            return (note, noteOn.velocity)
+        }
+        guard notes.isEmpty == false else { return }
+
+        try ensureReady()
+
+        oneShotStopTask?.cancel()
+        oneShotStopTask = nil
+
+        stopOneShotNotes()
+
+        for (note, velocity) in notes {
+            try? outputService.sendNoteOn(
+                note: note,
+                velocity: velocity,
+                channel: channel,
+                destinationUniqueID: destinationUniqueID
+            )
+            playingOneShotNotes.insert(note)
+        }
+
+        oneShotStopTask = Task.detached(priority: .userInitiated) { [weak self] in
+            try? await Task.sleep(for: .seconds(max(0, durationSeconds)))
+            guard Task.isCancelled == false else { return }
+            await MainActor.run { [weak self] in
+                self?.stopOneShotNotes()
+            }
+        }
+    }
+
     func startLiveNotes(midiNotes: Set<Int>) throws {
         try ensureReady()
         for midiNote in midiNotes {

--- a/LonelyPianistAVP/Services/Audio/PracticeManualReplaySequenceBuilder.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeManualReplaySequenceBuilder.swift
@@ -46,12 +46,14 @@ struct PracticeManualReplaySequenceBuilder {
                 )
             )
 
-            let uniqueMIDINotes = Set(step.notes.map(\.midiNote)).sorted()
-            for midi in uniqueMIDINotes {
+            let velocityByMIDINote = Dictionary(grouping: step.notes, by: \.midiNote)
+                .compactMapValues { notes in notes.map(\.velocity).max() ?? velocity }
+
+            for (midi, noteVelocity) in velocityByMIDINote.sorted(by: { $0.key < $1.key }) {
                 schedule.append(
                     PracticeSequencerMIDIEvent(
                         timeSeconds: stepSeconds,
-                        kind: .noteOn(midi: midi, velocity: velocity)
+                        kind: .noteOn(midi: midi, velocity: noteVelocity)
                     )
                 )
                 schedule.append(

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
@@ -20,17 +20,10 @@ protocol PracticeSequencerPlaybackServiceProtocol: AnyObject {
     func load(sequence: PracticeSequencerSequence) throws
     func play(fromSeconds start: TimeInterval) throws
     func currentSeconds() -> TimeInterval
-    func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws
     func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws
     func startLiveNotes(midiNotes: Set<Int>) throws
     func stopLiveNotes(midiNotes: Set<Int>)
     func stopAllLiveNotes()
-}
-
-extension PracticeSequencerPlaybackServiceProtocol {
-    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
-        try playOneShot(midiNotes: noteOns.map(\.midiNote), durationSeconds: durationSeconds)
-    }
 }
 
 @MainActor
@@ -122,31 +115,6 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
 
     func currentSeconds() -> TimeInterval {
         sequencer.currentPositionInSeconds
-    }
-
-    func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws {
-        let notes = midiNotes.compactMap { UInt8(exactly: $0) }
-        guard notes.isEmpty == false else { return }
-
-        try ensureReady()
-        applyAudioOutputVolumeIfNeeded()
-
-        oneShotStopTask?.cancel()
-        oneShotStopTask = nil
-
-        stopOneShotNotes()
-
-        for note in notes {
-            sampler.startNote(note, withVelocity: velocity, onChannel: channel)
-            playingOneShotNotes.insert(note)
-        }
-
-        oneShotStopTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(for: .seconds(max(0, durationSeconds)))
-            guard Task.isCancelled == false else { return }
-            stopOneShotNotes()
-        }
     }
 
     func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
@@ -5,6 +5,7 @@ import Foundation
 struct PracticeSequencerSequence: Sendable {
     let midiData: Data
     let durationSeconds: TimeInterval
+    let events: [PracticeSequencerMIDIEvent]
 }
 
 @MainActor

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
@@ -25,6 +25,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
     private let engine: AVAudioEngine
     private let sampler: AVAudioUnitSampler
     private let sequencer: AVAudioSequencer
+    private let userDefaults: UserDefaults
 
     private let soundFontResourceName: String
     private let program: UInt8
@@ -32,12 +33,15 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
     private let channel: UInt8
 
     private var isReady = false
+    private var currentAudioOutputVolume: Float?
+    private let volumeObserver = VolumeChangeObserver()
     private var playingOneShotNotes: Set<UInt8> = []
     private var oneShotStopTask: Task<Void, Never>?
     private var liveNotes: Set<UInt8> = []
 
     init(
         soundFontResourceName: String,
+        userDefaults: UserDefaults = .standard,
         program: UInt8 = 0,
         velocity: UInt8 = 96,
         channel: UInt8 = 0
@@ -45,6 +49,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
         engine = AVAudioEngine()
         sampler = AVAudioUnitSampler()
         sequencer = AVAudioSequencer(audioEngine: engine)
+        self.userDefaults = userDefaults
 
         self.soundFontResourceName = soundFontResourceName
         self.program = program
@@ -53,6 +58,14 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
 
         engine.attach(sampler)
         engine.connect(sampler, to: engine.mainMixerNode, format: nil)
+
+        applyAudioOutputVolumeIfNeeded()
+        volumeObserver.observeUserDefaultsDidChange { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.applyAudioOutputVolumeIfNeeded()
+            }
+        }
     }
 
     func warmUp() throws {
@@ -71,6 +84,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
 
     func load(sequence: PracticeSequencerSequence) throws {
         try ensureReady()
+        applyAudioOutputVolumeIfNeeded()
 
         stop()
 
@@ -87,6 +101,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
 
     func play(fromSeconds start: TimeInterval) throws {
         try ensureReady()
+        applyAudioOutputVolumeIfNeeded()
 
         sequencer.currentPositionInSeconds = max(0, start)
         try sequencer.start()
@@ -101,6 +116,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
         guard notes.isEmpty == false else { return }
 
         try ensureReady()
+        applyAudioOutputVolumeIfNeeded()
 
         oneShotStopTask?.cancel()
         oneShotStopTask = nil
@@ -122,6 +138,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
 
     func startLiveNotes(midiNotes: Set<Int>) throws {
         try ensureReady()
+        applyAudioOutputVolumeIfNeeded()
         for midiNote in midiNotes {
             guard let note = UInt8(exactly: midiNote), liveNotes.contains(note) == false else { continue }
             sampler.startNote(note, withVelocity: velocity, onChannel: channel)
@@ -171,6 +188,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
             if engine.isRunning == false {
                 configureSessionBestEffort()
                 do {
+                    applyAudioOutputVolumeIfNeeded()
                     engine.prepare()
                     try engine.start()
                 } catch {
@@ -196,6 +214,7 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
                 bankMSB: UInt8(kAUSampler_DefaultMelodicBankMSB),
                 bankLSB: 0
             )
+            applyAudioOutputVolumeIfNeeded()
             engine.prepare()
             try engine.start()
             isReady = true
@@ -204,6 +223,34 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
                 resourceName: soundFontResourceName,
                 detail: error.localizedDescription
             )
+        }
+    }
+
+    private func applyAudioOutputVolumeIfNeeded() {
+        let volume = AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults)
+        guard currentAudioOutputVolume != volume else { return }
+        currentAudioOutputVolume = volume
+        engine.mainMixerNode.outputVolume = volume
+    }
+}
+
+private final class VolumeChangeObserver: @unchecked Sendable {
+    private var token: NSObjectProtocol?
+
+    func observeUserDefaultsDidChange(_ onChange: @escaping @Sendable () -> Void) {
+        guard token == nil else { return }
+        token = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            onChange()
+        }
+    }
+
+    deinit {
+        if let token {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 }

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerPlaybackService.swift
@@ -8,6 +8,11 @@ struct PracticeSequencerSequence: Sendable {
     let events: [PracticeSequencerMIDIEvent]
 }
 
+struct PracticeOneShotNoteOn: Hashable, Sendable {
+    let midiNote: Int
+    let velocity: UInt8
+}
+
 @MainActor
 protocol PracticeSequencerPlaybackServiceProtocol: AnyObject {
     func warmUp() throws
@@ -16,9 +21,16 @@ protocol PracticeSequencerPlaybackServiceProtocol: AnyObject {
     func play(fromSeconds start: TimeInterval) throws
     func currentSeconds() -> TimeInterval
     func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws
     func startLiveNotes(midiNotes: Set<Int>) throws
     func stopLiveNotes(midiNotes: Set<Int>)
     func stopAllLiveNotes()
+}
+
+extension PracticeSequencerPlaybackServiceProtocol {
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
+        try playOneShot(midiNotes: noteOns.map(\.midiNote), durationSeconds: durationSeconds)
+    }
 }
 
 @MainActor
@@ -125,6 +137,34 @@ final class AVAudioSequencerPracticePlaybackService: PracticeSequencerPlaybackSe
         stopOneShotNotes()
 
         for note in notes {
+            sampler.startNote(note, withVelocity: velocity, onChannel: channel)
+            playingOneShotNotes.insert(note)
+        }
+
+        oneShotStopTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(max(0, durationSeconds)))
+            guard Task.isCancelled == false else { return }
+            stopOneShotNotes()
+        }
+    }
+
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
+        let notes = noteOns.compactMap { noteOn -> (note: UInt8, velocity: UInt8)? in
+            guard let note = UInt8(exactly: noteOn.midiNote) else { return nil }
+            return (note, noteOn.velocity)
+        }
+        guard notes.isEmpty == false else { return }
+
+        try ensureReady()
+        applyAudioOutputVolumeIfNeeded()
+
+        oneShotStopTask?.cancel()
+        oneShotStopTask = nil
+
+        stopOneShotNotes()
+
+        for (note, velocity) in notes {
             sampler.startNote(note, withVelocity: velocity, onChannel: channel)
             playingOneShotNotes.insert(note)
         }

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerSequenceBuilder.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerSequenceBuilder.swift
@@ -180,7 +180,8 @@ struct PracticeSequencerSequenceBuilder {
 
         return PracticeSequencerSequence(
             midiData: exportedData.takeRetainedValue() as Data,
-            durationSeconds: durationSeconds
+            durationSeconds: durationSeconds,
+            events: sortedSchedule
         )
     }
 

--- a/LonelyPianistAVP/Services/Audio/PracticeSequencerSequenceBuilder.swift
+++ b/LonelyPianistAVP/Services/Audio/PracticeSequencerSequenceBuilder.swift
@@ -2,7 +2,7 @@ import AudioToolbox
 import Foundation
 
 struct PracticeSequencerMIDIEvent: Equatable, Sendable {
-    enum Kind: Equatable {
+    enum Kind: Equatable, Sendable {
         case noteOn(midi: Int, velocity: UInt8)
         case noteOff(midi: Int)
         case controlChange(controller: UInt8, value: UInt8)

--- a/LonelyPianistAVP/Services/Library/SongAudioPlayer.swift
+++ b/LonelyPianistAVP/Services/Library/SongAudioPlayer.swift
@@ -19,7 +19,26 @@ final class SongAudioPlayer: NSObject, SongAudioPlayerProtocol, AVAudioPlayerDel
     var onPlaybackFinished: ((UUID?) -> Void)?
     private(set) var currentEntryID: UUID?
 
+    private let userDefaults: UserDefaults
     private var audioPlayer: AVAudioPlayer?
+    private var currentAudioOutputVolume: Float?
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        super.init()
+
+        applyAudioOutputVolumeIfNeeded()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleUserDefaultsDidChange),
+            name: UserDefaults.didChangeNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UserDefaults.didChangeNotification, object: nil)
+    }
 
     func play(entryID: UUID, url: URL) throws {
         if currentEntryID != entryID {
@@ -39,6 +58,7 @@ final class SongAudioPlayer: NSObject, SongAudioPlayerProtocol, AVAudioPlayerDel
             throw SongAudioPlayerStateError.cannotCreatePlayer
         }
 
+        applyAudioOutputVolumeIfNeeded()
         audioPlayer.play()
     }
 
@@ -62,6 +82,18 @@ final class SongAudioPlayer: NSObject, SongAudioPlayerProtocol, AVAudioPlayerDel
         audioPlayer = nil
         currentEntryID = nil
         onPlaybackFinished?(finishedEntryID)
+    }
+
+    private func applyAudioOutputVolumeIfNeeded() {
+        let volume = AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults)
+        let playerVolume = audioPlayer?.volume
+        guard currentAudioOutputVolume != volume || playerVolume != volume else { return }
+        currentAudioOutputVolume = volume
+        audioPlayer?.volume = volume
+    }
+
+    @objc private func handleUserDefaultsDidChange() {
+        applyAudioOutputVolumeIfNeeded()
     }
 }
 

--- a/LonelyPianistAVP/Services/MIDI/CoreMIDIOutputService.swift
+++ b/LonelyPianistAVP/Services/MIDI/CoreMIDIOutputService.swift
@@ -3,6 +3,20 @@ import Foundation
 import OSLog
 import os
 
+protocol MIDIOutputSendingProtocol: AnyObject, Sendable {
+    func start() throws
+    func stop()
+    func listDestinations() -> [MIDIDestinationInfo]
+
+    func sendMIDI1Bytes(_ bytes: [UInt8], destinationUniqueID: Int32) throws
+    func sendNoteOn(note: UInt8, velocity: UInt8, channel: UInt8, destinationUniqueID: Int32) throws
+    func sendNoteOff(note: UInt8, channel: UInt8, destinationUniqueID: Int32) throws
+    func sendControlChange(controller: UInt8, value: UInt8, channel: UInt8, destinationUniqueID: Int32) throws
+    func sendProgramChange(program: UInt8, channel: UInt8, destinationUniqueID: Int32) throws
+    func sendAllNotesOff(channel: UInt8, destinationUniqueID: Int32) throws
+    func sendAllSoundOff(channel: UInt8, destinationUniqueID: Int32) throws
+}
+
 struct MIDIDestinationInfo: Identifiable, Equatable, Sendable {
     let id: Int32
     let name: String
@@ -28,7 +42,7 @@ enum CoreMIDIOutputServiceError: LocalizedError {
     }
 }
 
-final class CoreMIDIOutputService: @unchecked Sendable {
+final class CoreMIDIOutputService: MIDIOutputSendingProtocol, @unchecked Sendable {
     var onDestinationListChange: (@Sendable ([MIDIDestinationInfo]) -> Void)?
     var onLastErrorMessageChange: (@Sendable (String?) -> Void)?
 

--- a/LonelyPianistAVP/Services/MIDI/CoreMIDIOutputService.swift
+++ b/LonelyPianistAVP/Services/MIDI/CoreMIDIOutputService.swift
@@ -1,0 +1,237 @@
+import CoreMIDI
+import Foundation
+import OSLog
+import os
+
+struct MIDIDestinationInfo: Identifiable, Equatable, Sendable {
+    let id: Int32
+    let name: String
+}
+
+enum CoreMIDIOutputServiceError: LocalizedError {
+    case clientCreate(OSStatus)
+    case outputPortCreate(OSStatus)
+    case destinationNotFound(Int32)
+    case send(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case let .clientCreate(status):
+            "Failed to create MIDI client: \(status)"
+        case let .outputPortCreate(status):
+            "Failed to create MIDI output port: \(status)"
+        case let .destinationNotFound(id):
+            "MIDI destination not found: \(id)"
+        case let .send(status):
+            "Failed to send MIDI message: \(status)"
+        }
+    }
+}
+
+final class CoreMIDIOutputService: @unchecked Sendable {
+    var onDestinationListChange: (@Sendable ([MIDIDestinationInfo]) -> Void)?
+    var onLastErrorMessageChange: (@Sendable (String?) -> Void)?
+
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "LonelyPianistAVP", category: "CoreMIDI-AVP-Output")
+    private let refreshScheduler = DebouncedActionScheduler(debounce: .milliseconds(200))
+
+    private var clientRef: MIDIClientRef = 0
+    private var outputPortRef: MIDIPortRef = 0
+    private let stateLock = OSAllocatedUnfairLock(initialState: OutputState())
+
+    func start() throws {
+        try createClientIfNeeded()
+        try createOutputPortIfNeeded()
+        refreshDestinations()
+    }
+
+    func stop() {
+        refreshScheduler.cancel()
+
+        stateLock.withLock { state in
+            state.destinationCache.removeAll(keepingCapacity: false)
+        }
+
+        if outputPortRef != 0 {
+            MIDIPortDispose(outputPortRef)
+            outputPortRef = 0
+        }
+
+        if clientRef != 0 {
+            MIDIClientDispose(clientRef)
+            clientRef = 0
+        }
+
+        onLastErrorMessageChange?(nil)
+        onDestinationListChange?([])
+    }
+
+    func listDestinations() -> [MIDIDestinationInfo] {
+        let results = refreshDestinations()
+        return results
+    }
+
+    @discardableResult
+    func refreshDestinations() -> [MIDIDestinationInfo] {
+        var newDestinationCache: [Int32: MIDIEndpointRef] = [:]
+
+        let count = MIDIGetNumberOfDestinations()
+        var results: [MIDIDestinationInfo] = []
+        results.reserveCapacity(max(0, count))
+
+        for index in 0 ..< count {
+            let endpoint = MIDIGetDestination(index)
+            guard endpoint != 0 else { continue }
+
+            guard let uniqueID = endpointUniqueID(endpoint) else { continue }
+            let name = endpointName(endpoint)
+            newDestinationCache[uniqueID] = endpoint
+            results.append(MIDIDestinationInfo(id: uniqueID, name: name))
+        }
+
+        results.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        let destinationCache = newDestinationCache
+        stateLock.withLock { state in
+            state.destinationCache = destinationCache
+        }
+
+        onDestinationListChange?(results)
+        onLastErrorMessageChange?(nil)
+        return results
+    }
+
+    func sendMIDI1Bytes(_ bytes: [UInt8], destinationUniqueID: Int32) throws {
+        try createClientIfNeeded()
+        try createOutputPortIfNeeded()
+
+        let destination = try resolveDestination(destinationUniqueID)
+        try sendBytes(bytes, destination: destination)
+    }
+
+    func sendNoteOn(note: UInt8, velocity: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        let status: UInt8 = 0x90 | (channel & 0x0F)
+        try sendMIDI1Bytes([status, note, velocity], destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendNoteOff(note: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        let status: UInt8 = 0x80 | (channel & 0x0F)
+        try sendMIDI1Bytes([status, note, 0], destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendControlChange(controller: UInt8, value: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        let status: UInt8 = 0xB0 | (channel & 0x0F)
+        try sendMIDI1Bytes([status, controller, value], destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendProgramChange(program: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        let status: UInt8 = 0xC0 | (channel & 0x0F)
+        try sendMIDI1Bytes([status, program], destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendAllNotesOff(channel: UInt8, destinationUniqueID: Int32) throws {
+        try sendControlChange(controller: 123, value: 0, channel: channel, destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendAllSoundOff(channel: UInt8, destinationUniqueID: Int32) throws {
+        try sendControlChange(controller: 120, value: 0, channel: channel, destinationUniqueID: destinationUniqueID)
+    }
+
+    private func createClientIfNeeded() throws {
+        guard clientRef == 0 else { return }
+
+        let status = MIDIClientCreateWithBlock(
+            "LonelyPianistAVPOutputClient" as CFString,
+            &clientRef
+        ) { [weak self] message in
+            guard let self else { return }
+            let notification = message.pointee
+            Task { @MainActor [weak self] in
+                self?.handleMIDINotification(notification)
+            }
+        }
+
+        guard status == noErr else {
+            throw CoreMIDIOutputServiceError.clientCreate(status)
+        }
+    }
+
+    private func createOutputPortIfNeeded() throws {
+        guard outputPortRef == 0 else { return }
+        let status = MIDIOutputPortCreate(clientRef, "LonelyPianistAVPOutputPort" as CFString, &outputPortRef)
+        guard status == noErr else {
+            throw CoreMIDIOutputServiceError.outputPortCreate(status)
+        }
+    }
+
+    private func handleMIDINotification(_ notification: MIDINotification) {
+        _ = notification
+        scheduleRefreshDestinations()
+    }
+
+    private func scheduleRefreshDestinations() {
+        refreshScheduler.schedule { [weak self] in
+            guard let self else { return }
+            _ = self.refreshDestinations()
+        }
+    }
+
+    private func resolveDestination(_ destinationUniqueID: Int32) throws -> MIDIEndpointRef {
+        if let endpoint = stateLock.withLock({ $0.destinationCache[destinationUniqueID] }), endpoint != 0 {
+            return endpoint
+        }
+
+        let destinations = refreshDestinations()
+        if destinations.contains(where: { $0.id == destinationUniqueID }),
+           let endpoint = stateLock.withLock({ $0.destinationCache[destinationUniqueID] }),
+           endpoint != 0
+        {
+            return endpoint
+        }
+
+        throw CoreMIDIOutputServiceError.destinationNotFound(destinationUniqueID)
+    }
+
+    private func sendBytes(_ bytes: [UInt8], destination: MIDIEndpointRef) throws {
+        let bufferSize = 1024
+        let buffer = UnsafeMutableRawPointer.allocate(
+            byteCount: bufferSize,
+            alignment: MemoryLayout<MIDIPacketList>.alignment
+        )
+        defer { buffer.deallocate() }
+
+        let packetListPtr = buffer.assumingMemoryBound(to: MIDIPacketList.self)
+        packetListPtr.initialize(to: MIDIPacketList())
+
+        var packet = MIDIPacketListInit(packetListPtr)
+        bytes.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+            packet = MIDIPacketListAdd(packetListPtr, bufferSize, packet, 0, bytes.count, base)
+        }
+
+        let statusSend = MIDISend(outputPortRef, destination, packetListPtr)
+        guard statusSend == noErr else {
+            logger.error("MIDISend failed: \(statusSend, privacy: .public)")
+            onLastErrorMessageChange?("MIDISend failed: \(statusSend)")
+            throw CoreMIDIOutputServiceError.send(statusSend)
+        }
+    }
+
+    private func endpointName(_ endpoint: MIDIEndpointRef) -> String {
+        if let displayName = MIDIEndpointPropertyReader.stringProperty(endpoint, kMIDIPropertyDisplayName) {
+            return displayName
+        }
+        if let name = MIDIEndpointPropertyReader.stringProperty(endpoint, kMIDIPropertyName) {
+            return name
+        }
+        return "Unknown MIDI Destination"
+    }
+
+    private func endpointUniqueID(_ endpoint: MIDIEndpointRef) -> Int32? {
+        MIDIEndpointPropertyReader.int32Property(endpoint, kMIDIPropertyUniqueID)
+    }
+}
+
+private struct OutputState {
+    var destinationCache: [Int32: MIDIEndpointRef] = [:]
+}

--- a/LonelyPianistAVP/Services/Practice/Playback/PracticePlaybackControlService.swift
+++ b/LonelyPianistAVP/Services/Practice/Playback/PracticePlaybackControlService.swift
@@ -92,12 +92,16 @@ final class PracticePlaybackControlService: PracticePlaybackControlServiceProtoc
 
         let mode = handModeProvider()
         let expectedNotes = mode == .both ? currentStep.notes : currentStep.notes.filter { mode.allows(hand: $0.hand) }
-        let midiNotes = Set(expectedNotes.map(\.midiNote)).sorted()
-        guard midiNotes.isEmpty == false else { return }
+        let velocityByMIDINote = Dictionary(grouping: expectedNotes, by: \.midiNote)
+            .compactMapValues { notes in notes.map(\.velocity).max() }
+        let noteOns = velocityByMIDINote
+            .map { PracticeOneShotNoteOn(midiNote: $0.key, velocity: $0.value) }
+            .sorted { $0.midiNote < $1.midiNote }
+        guard noteOns.isEmpty == false else { return }
 
         do {
             try sequencerPlaybackService.playOneShot(
-                midiNotes: midiNotes,
+                noteOns: noteOns,
                 durationSeconds: 0.35
             )
         } catch {

--- a/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
+++ b/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
@@ -57,7 +57,7 @@ struct UserDefaultsPracticeSessionSettingsProvider: PracticeSessionSettingsProvi
         let midiDestinationUniqueID: Int32?
         if let number = userDefaults.object(forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID) as? NSNumber {
             let value = number.int32Value
-            midiDestinationUniqueID = value > 0 ? value : nil
+            midiDestinationUniqueID = value != 0 ? value : nil
         } else {
             midiDestinationUniqueID = nil
         }

--- a/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
+++ b/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
@@ -56,7 +56,8 @@ struct UserDefaultsPracticeSessionSettingsProvider: PracticeSessionSettingsProvi
 
         let midiDestinationUniqueID: Int32?
         if let number = userDefaults.object(forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID) as? NSNumber {
-            midiDestinationUniqueID = number.int32Value
+            let value = number.int32Value
+            midiDestinationUniqueID = value > 0 ? value : nil
         } else {
             midiDestinationUniqueID = nil
         }

--- a/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
+++ b/LonelyPianistAVP/Services/Practice/Settings/PracticeSessionSettingsProvider.swift
@@ -5,12 +5,17 @@ enum PracticeSessionSettingsKeys {
     static let handMode = "practiceHandMode"
     static let audioRecognitionDetectorMode = "practiceStep3AudioRecognitionMode"
     static let improvBackendKind = "practiceImprovBackendKind"
+
+    static let soundOutputRoute = "practiceSoundOutputRoute"
+    static let midiDestinationUniqueID = "practiceMIDIDestinationUniqueID"
+    static let sendLocalControlOff = "practiceSendLocalControlOff"
 }
 
 protocol PracticeSessionSettingsProviderProtocol {
     var manualAdvanceMode: ManualAdvanceMode { get }
     var practiceHandMode: PracticeHandMode { get }
     var audioRecognitionDetectorMode: PracticeAudioRecognitionDetectorMode { get }
+    var soundRoutingSettings: PracticeSoundRoutingSettings { get }
 }
 
 struct UserDefaultsPracticeSessionSettingsProvider: PracticeSessionSettingsProviderProtocol {
@@ -37,5 +42,29 @@ struct UserDefaultsPracticeSessionSettingsProvider: PracticeSessionSettingsProvi
             return .harmonicTemplate
         }
         return mode
+    }
+
+    var soundRoutingSettings: PracticeSoundRoutingSettings {
+        let outputRoute: PracticeSoundOutputRoute
+        if let rawValue = userDefaults.string(forKey: PracticeSessionSettingsKeys.soundOutputRoute),
+           let route = PracticeSoundOutputRoute(rawValue: rawValue)
+        {
+            outputRoute = route
+        } else {
+            outputRoute = .localSampler
+        }
+
+        let midiDestinationUniqueID: Int32?
+        if let number = userDefaults.object(forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID) as? NSNumber {
+            midiDestinationUniqueID = number.int32Value
+        } else {
+            midiDestinationUniqueID = nil
+        }
+
+        return PracticeSoundRoutingSettings(
+            outputRoute: outputRoute,
+            midiDestinationUniqueID: midiDestinationUniqueID,
+            sendLocalControlOff: userDefaults.bool(forKey: PracticeSessionSettingsKeys.sendLocalControlOff)
+        )
     }
 }

--- a/LonelyPianistAVP/Services/Practice/Settings/PracticeSoundRoutingSettings.swift
+++ b/LonelyPianistAVP/Services/Practice/Settings/PracticeSoundRoutingSettings.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum PracticeSoundOutputRoute: String, CaseIterable, Identifiable, Sendable {
+    case localSampler
+    case externalMIDIDestination
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .localSampler:
+            "仅 AVP 发声"
+        case .externalMIDIDestination:
+            "仅真实钢琴发声"
+        }
+    }
+}
+
+struct PracticeSoundRoutingSettings: Sendable {
+    let outputRoute: PracticeSoundOutputRoute
+    let midiDestinationUniqueID: Int32?
+    let sendLocalControlOff: Bool
+}
+

--- a/LonelyPianistAVP/ViewModels/ARGuide/ARGuideViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuide/ARGuideViewModel.swift
@@ -98,6 +98,10 @@ final class ARGuideViewModel {
         selectedPianoMode?.isVirtualPianoMode == true
     }
 
+    var isBluetoothMIDIMode: Bool {
+        PianoModeID(rawValue: practiceSetupState.selectedPianoModeID ?? "") == .bluetoothMIDI
+    }
+
     var backendDiscoveryService: BonjourBackendDiscoveryService {
         aiPerformanceViewModel.backendDiscoveryService
     }

--- a/LonelyPianistAVP/ViewModels/AppState.swift
+++ b/LonelyPianistAVP/ViewModels/AppState.swift
@@ -287,7 +287,7 @@ class AppState {
         let makePressDetectionService: () -> PressDetectionServiceProtocol = { PressDetectionService() }
         let makeChordAttemptAccumulator: () -> ChordAttemptAccumulatorProtocol = { ChordAttemptAccumulator() }
         let makeSleeper: () -> SleeperProtocol = { TaskSleeper() }
-        let makeSequencerPlaybackService: () -> PracticeSequencerPlaybackServiceProtocol = {
+        let makeLocalSamplerPlaybackService: () -> PracticeSequencerPlaybackServiceProtocol = {
             AVAudioSequencerPracticePlaybackService(soundFontResourceName: "SalC5Light2")
         }
         let makeAudioStepAttemptAccumulator: () -> AudioStepAttemptAccumulator = {
@@ -313,23 +313,38 @@ class AppState {
         let makePracticeSessionViewModel: @MainActor (String?) -> PracticeSessionViewModel = { pianoModeID in
                 switch PianoModeID(rawValue: pianoModeID ?? "") {
                     case .bluetoothMIDI:
-                        PracticeSessionViewModel(
+                        let settingsProvider = UserDefaultsPracticeSessionSettingsProvider()
+                        let routing = settingsProvider.soundRoutingSettings
+                        let sequencerPlaybackService: PracticeSequencerPlaybackServiceProtocol
+                        switch routing.outputRoute {
+                        case .localSampler:
+                            sequencerPlaybackService = makeLocalSamplerPlaybackService()
+                        case .externalMIDIDestination:
+                            if let destinationUniqueID = routing.midiDestinationUniqueID {
+                                sequencerPlaybackService = CoreMIDIPracticePlaybackService(destinationUniqueID: destinationUniqueID)
+                            } else {
+                                sequencerPlaybackService = makeLocalSamplerPlaybackService()
+                            }
+                        }
+
+                        return PracticeSessionViewModel(
                             pressDetectionService: makePressDetectionService(),
                             chordAttemptAccumulator: makeChordAttemptAccumulator(),
                             sleeper: makeSleeper(),
-                            sequencerPlaybackService: makeSequencerPlaybackService(),
+                            sequencerPlaybackService: sequencerPlaybackService,
                             audioRecognitionService: nil,
                             practiceInputEventSource: makeBluetoothMIDIEventSource(),
                             audioStepAttemptAccumulator: makeAudioStepAttemptAccumulator(),
-                            handPianoActivityGate: makeHandPianoActivityGate()
+                            handPianoActivityGate: makeHandPianoActivityGate(),
+                            settingsProvider: settingsProvider
                         )
 
                     case .virtualPiano:
-                        PracticeSessionViewModel(
+                        return PracticeSessionViewModel(
                             pressDetectionService: makePressDetectionService(),
                             chordAttemptAccumulator: makeChordAttemptAccumulator(),
                             sleeper: makeSleeper(),
-                            sequencerPlaybackService: makeSequencerPlaybackService(),
+                            sequencerPlaybackService: makeLocalSamplerPlaybackService(),
                             audioRecognitionService: nil,
                             practiceInputEventSource: nil,
                             audioStepAttemptAccumulator: makeAudioStepAttemptAccumulator(),
@@ -337,11 +352,11 @@ class AppState {
                         )
 
                     default:
-                        PracticeSessionViewModel(
+                        return PracticeSessionViewModel(
                             pressDetectionService: makePressDetectionService(),
                             chordAttemptAccumulator: makeChordAttemptAccumulator(),
                             sleeper: makeSleeper(),
-                            sequencerPlaybackService: makeSequencerPlaybackService(),
+                            sequencerPlaybackService: makeLocalSamplerPlaybackService(),
                             audioRecognitionService: makeAudioRecognitionService(),
                             practiceInputEventSource: nil,
                             audioStepAttemptAccumulator: makeAudioStepAttemptAccumulator(),

--- a/LonelyPianistAVP/ViewModels/MIDI/MIDIDestinationConnectionViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/MIDI/MIDIDestinationConnectionViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MIDIDestinationConnectionViewModel {
+    private let outputService: CoreMIDIOutputService
+
+    var destinations: [MIDIDestinationInfo] = []
+    var lastErrorMessage: String?
+
+    init(outputService: CoreMIDIOutputService? = nil) {
+        let outputService = outputService ?? CoreMIDIOutputService()
+        self.outputService = outputService
+
+        outputService.onDestinationListChange = { [weak self] destinations in
+            Task { @MainActor [weak self] in
+                self?.destinations = destinations
+            }
+        }
+
+        outputService.onLastErrorMessageChange = { [weak self] message in
+            Task { @MainActor [weak self] in
+                self?.lastErrorMessage = message
+            }
+        }
+    }
+
+    func start() {
+        do {
+            try outputService.start()
+            destinations = outputService.listDestinations()
+        } catch {
+            lastErrorMessage = error.localizedDescription
+            destinations = []
+        }
+    }
+
+    func stop() {
+        outputService.stop()
+    }
+
+    func refreshDestinations() {
+        destinations = outputService.listDestinations()
+    }
+
+    func sendLocalControlOff(_ enabled: Bool, destinationUniqueID: Int32) {
+        let value: UInt8 = enabled ? 0 : 127
+        do {
+            for channel in UInt8(0) ..< 16 {
+                try outputService.sendControlChange(
+                    controller: 122,
+                    value: value,
+                    channel: channel,
+                    destinationUniqueID: destinationUniqueID
+                )
+            }
+            lastErrorMessage = nil
+        } catch {
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+}

--- a/LonelyPianistAVP/Views/Library/LibraryContentView.swift
+++ b/LonelyPianistAVP/Views/Library/LibraryContentView.swift
@@ -7,6 +7,8 @@ struct LibraryContentView: View {
     let onBackToPreparation: @MainActor () -> Void
     let onStartPractice: @MainActor () -> Void
 
+    @State private var isAudioOutputVolumePresented = false
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -24,6 +26,16 @@ struct LibraryContentView: View {
                 .buttonStyle(.bordered)
 
                 Spacer()
+
+                Button("音量", systemImage: "speaker.wave.2") {
+                    isAudioOutputVolumePresented = true
+                }
+                .buttonStyle(.bordered)
+                .popover(isPresented: $isAudioOutputVolumePresented) {
+                    AudioOutputVolumeRow()
+                        .padding(16)
+                        .frame(minWidth: 360)
+                }
 
                 Button("导入 MusicXML") {
                     songLibraryViewModel.didTapImportMusicXML()

--- a/LonelyPianistAVP/Views/PianoChoose/BluetoothPianoPreparationView.swift
+++ b/LonelyPianistAVP/Views/PianoChoose/BluetoothPianoPreparationView.swift
@@ -262,7 +262,7 @@ struct BluetoothMIDIConnectionSection: View {
     }
 
     private func applyLocalControlOffIfNeeded() {
-        guard midiDestinationUniqueID > 0 else { return }
+        guard midiDestinationUniqueID != 0 else { return }
         guard let destinationUniqueID = Int32(exactly: midiDestinationUniqueID) else { return }
         destinationConnectionViewModel.sendLocalControlOff(sendLocalControlOff, destinationUniqueID: destinationUniqueID)
     }

--- a/LonelyPianistAVP/Views/PianoChoose/BluetoothPianoPreparationView.swift
+++ b/LonelyPianistAVP/Views/PianoChoose/BluetoothPianoPreparationView.swift
@@ -58,9 +58,17 @@ struct BluetoothMIDIConnectionSection: View {
 
     @State private var bluetoothAccessViewModel = BluetoothAccessViewModel()
     @State private var sourceConnectionViewModel = MIDISourceConnectionViewModel()
+    @State private var destinationConnectionViewModel = MIDIDestinationConnectionViewModel()
     @State private var centralViewReloadID = UUID()
     @State private var isDiagnosticsExpanded = false
     @State private var isDevicePickerPresented = false
+
+    @AppStorage(PracticeSessionSettingsKeys.soundOutputRoute)
+    private var soundOutputRouteRawValue = PracticeSoundOutputRoute.localSampler.rawValue
+    @AppStorage(PracticeSessionSettingsKeys.midiDestinationUniqueID)
+    private var midiDestinationUniqueID = 0
+    @AppStorage(PracticeSessionSettingsKeys.sendLocalControlOff)
+    private var sendLocalControlOff = false
 
     init(
         onSourceCountChange: @escaping @MainActor (Int) -> Void
@@ -108,6 +116,44 @@ struct BluetoothMIDIConnectionSection: View {
                         .font(.callout)
 
                         Spacer()
+                    }
+
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        Picker("发声路由", selection: $soundOutputRouteRawValue) {
+                            ForEach(PracticeSoundOutputRoute.allCases) { route in
+                                Text(route.title).tag(route.rawValue)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+
+                        HStack(spacing: 12) {
+                            Picker("MIDI 输出目的地", selection: $midiDestinationUniqueID) {
+                                Text("未选择").tag(0)
+                                ForEach(destinationConnectionViewModel.destinations) { destination in
+                                    Text(destination.name).tag(Int(destination.id))
+                                }
+                            }
+                            .pickerStyle(.menu)
+
+                            Button("刷新输出", systemImage: "arrow.clockwise") {
+                                destinationConnectionViewModel.refreshDestinations()
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Toggle("Local Control Off（可选）", isOn: $sendLocalControlOff)
+
+                        Text("若选择“仅 AVP 发声”，你可以在钢琴上手动关闭本地音量；或勾选此项让 AVP best-effort 向钢琴发送 Local Control Off（兼容性不保证）。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        if let message = destinationConnectionViewModel.lastErrorMessage {
+                            Text(message)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
 
                     DisclosureGroup("诊断信息", isExpanded: $isDiagnosticsExpanded) {
@@ -196,6 +242,7 @@ struct BluetoothMIDIConnectionSection: View {
         }
         .onAppear {
             sourceConnectionViewModel.start()
+            destinationConnectionViewModel.start()
             onSourceCountChange(sourceConnectionViewModel.sourceCount)
 
             Task { @MainActor in
@@ -204,7 +251,20 @@ struct BluetoothMIDIConnectionSection: View {
         }
         .onDisappear {
             sourceConnectionViewModel.stop()
+            destinationConnectionViewModel.stop()
         }
+        .onChange(of: sendLocalControlOff) {
+            applyLocalControlOffIfNeeded()
+        }
+        .onChange(of: midiDestinationUniqueID) {
+            applyLocalControlOffIfNeeded()
+        }
+    }
+
+    private func applyLocalControlOffIfNeeded() {
+        guard midiDestinationUniqueID > 0 else { return }
+        guard let destinationUniqueID = Int32(exactly: midiDestinationUniqueID) else { return }
+        destinationConnectionViewModel.sendLocalControlOff(sendLocalControlOff, destinationUniqueID: destinationUniqueID)
     }
 
     private func accessStatusCard(

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -12,6 +12,8 @@ struct PracticeSettingsView: View {
     let onRetryVirtualPianoPlacement: () -> Void
 
     @AppStorage("debugKeyboardAxesOverlayEnabled") private var debugKeyboardAxesOverlayEnabled = false
+    @AppStorage(AudioOutputVolumeSettings.userDefaultsKey)
+    private var audioOutputVolume = Double(AudioOutputVolumeSettings.defaultValue)
     @AppStorage(PracticeSessionSettingsKeys.manualAdvanceMode) private var manualAdvanceModeRawValue = ManualAdvanceMode.step.rawValue
     @AppStorage(PracticeSessionSettingsKeys.handMode) private var practiceHandModeRawValue = PracticeHandMode.both.rawValue
     @AppStorage(PracticeSessionSettingsKeys.improvBackendKind)
@@ -19,82 +21,97 @@ struct PracticeSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Toggle("AI 即兴演奏（虚拟演奏家）", isOn: $virtualPerformerEnabled)
-            if virtualPerformerEnabled {
-                Picker("即兴后端", selection: $improvBackendKindRawValue) {
-                    ForEach(ImprovBackendKind.allCases) { kind in
-                        Text(backendTitle(kind)).tag(kind.rawValue)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("输出音量")
+                HStack {
+                    Slider(value: $audioOutputVolume, in: 0...1)
+                    Text(audioOutputVolume, format: .percent)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 56, alignment: .trailing)
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle("AI 即兴演奏（虚拟演奏家）", isOn: $virtualPerformerEnabled)
+                if virtualPerformerEnabled {
+                    Picker("即兴后端", selection: $improvBackendKindRawValue) {
+                        ForEach(ImprovBackendKind.allCases) { kind in
+                            Text(backendTitle(kind)).tag(kind.rawValue)
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    if let effectiveBackendStatusText {
+                        Text(effectiveBackendStatusText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let lastImprovStatusText {
+                        Text(lastImprovStatusText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
                     }
                 }
-                .pickerStyle(.menu)
 
-                if let effectiveBackendStatusText {
-                    Text(effectiveBackendStatusText)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-                if let lastImprovStatusText {
-                    Text(lastImprovStatusText)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Divider()
-
-            if let recordingSourceText {
-                Text(recordingSourceText)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-
-            Button("打开录制库", systemImage: "list.bullet") {
-                onOpenTakeLibrary()
-            }
-            .buttonStyle(.bordered)
-            .buttonBorderShape(.roundedRectangle)
-            .hoverEffect()
-
-            Divider()
-
-            Toggle("调试：显示键盘坐标轴（X/Y/Z）", isOn: $debugKeyboardAxesOverlayEnabled)
-
-            Divider()
-
-            Picker("练习手", selection: $practiceHandModeRawValue) {
-                ForEach(PracticeHandMode.allCases) { mode in
-                    Text(mode.title).tag(mode.rawValue)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            Picker("手动前进方式", selection: $manualAdvanceModeRawValue) {
-                ForEach(ManualAdvanceMode.allCases) { mode in
-                    Text(mode.title).tag(mode.rawValue)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            if isVirtualPianoMode {
                 Divider()
 
-                if let gazePlaneDiskStatusText {
-                    Text(gazePlaneDiskStatusText)
-                        .font(.callout)
+                if let recordingSourceText {
+                    Text(recordingSourceText)
+                        .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
 
-                Button("重试放置", systemImage: "arrow.clockwise") {
-                    onRetryVirtualPianoPlacement()
+                Button("打开录制库", systemImage: "list.bullet") {
+                    onOpenTakeLibrary()
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.bordered)
                 .buttonBorderShape(.roundedRectangle)
                 .hoverEffect()
+
+                Divider()
+
+                Toggle("调试：显示键盘坐标轴（X/Y/Z）", isOn: $debugKeyboardAxesOverlayEnabled)
+
+                Divider()
+
+                Picker("练习手", selection: $practiceHandModeRawValue) {
+                    ForEach(PracticeHandMode.allCases) { mode in
+                        Text(mode.title).tag(mode.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("手动前进方式", selection: $manualAdvanceModeRawValue) {
+                    ForEach(ManualAdvanceMode.allCases) { mode in
+                        Text(mode.title).tag(mode.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if isVirtualPianoMode {
+                    Divider()
+
+                    if let gazePlaneDiskStatusText {
+                        Text(gazePlaneDiskStatusText)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button("重试放置", systemImage: "arrow.clockwise") {
+                        onRetryVirtualPianoPlacement()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.roundedRectangle)
+                    .hoverEffect()
+                }
             }
+            .disabled(isAIPerformanceActive)
         }
         .padding(16)
         .frame(minWidth: 320)
-        .disabled(isAIPerformanceActive)
     }
 
     private var effectiveBackendStatusText: String? {

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -22,7 +22,7 @@ struct PracticeSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("输出音量")
+                Text("输出音量（AVP）")
                 HStack {
                     Slider(value: $audioOutputVolume, in: 0...1)
                     Text(audioOutputVolume, format: .percent)
@@ -30,6 +30,9 @@ struct PracticeSettingsView: View {
                         .foregroundStyle(.secondary)
                         .frame(width: 56, alignment: .trailing)
                 }
+                Text("调到 0 可避免与真实钢琴叠音。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
 
             Divider()

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -7,9 +7,11 @@ struct PracticeSettingsView: View {
     let recordingSourceText: String?
     let isAIPerformanceActive: Bool
     let isVirtualPianoMode: Bool
+    let isBluetoothMIDIMode: Bool
     let gazePlaneDiskStatusText: String?
     let onOpenTakeLibrary: () -> Void
     let onRetryVirtualPianoPlacement: () -> Void
+    let onRequestSessionRebuild: () -> Void
 
     @AppStorage("debugKeyboardAxesOverlayEnabled") private var debugKeyboardAxesOverlayEnabled = false
     @AppStorage(AudioOutputVolumeSettings.userDefaultsKey)
@@ -18,6 +20,14 @@ struct PracticeSettingsView: View {
     @AppStorage(PracticeSessionSettingsKeys.handMode) private var practiceHandModeRawValue = PracticeHandMode.both.rawValue
     @AppStorage(PracticeSessionSettingsKeys.improvBackendKind)
     private var improvBackendKindRawValue = ImprovBackendKind.networkBonjourHTTP.rawValue
+    @AppStorage(PracticeSessionSettingsKeys.soundOutputRoute)
+    private var soundOutputRouteRawValue = PracticeSoundOutputRoute.localSampler.rawValue
+    @AppStorage(PracticeSessionSettingsKeys.midiDestinationUniqueID)
+    private var midiDestinationUniqueID = 0
+    @AppStorage(PracticeSessionSettingsKeys.sendLocalControlOff)
+    private var sendLocalControlOff = false
+
+    @State private var destinationConnectionViewModel = MIDIDestinationConnectionViewModel()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -36,6 +46,65 @@ struct PracticeSettingsView: View {
             }
 
             Divider()
+
+            if isBluetoothMIDIMode {
+                VStack(alignment: .leading, spacing: 12) {
+                    Picker("发声路由", selection: $soundOutputRouteRawValue) {
+                        ForEach(PracticeSoundOutputRoute.allCases) { route in
+                            Text(route.title).tag(route.rawValue)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    HStack(spacing: 12) {
+                        Picker("MIDI 输出目的地", selection: $midiDestinationUniqueID) {
+                            Text("未选择").tag(0)
+                            ForEach(destinationConnectionViewModel.destinations) { destination in
+                                Text(destination.name).tag(Int(destination.id))
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        Button("刷新输出", systemImage: "arrow.clockwise") {
+                            destinationConnectionViewModel.refreshDestinations()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+
+                    Toggle("Local Control Off（可选）", isOn: $sendLocalControlOff)
+
+                    Text("变更路由/目的地会重启当前练习会话（进度可能重置）。输出音量不会受影响。")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    Button("应用路由变更并重启会话", systemImage: "arrow.clockwise") {
+                        onRequestSessionRebuild()
+                    }
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.roundedRectangle)
+                    .hoverEffect()
+
+                    if let message = destinationConnectionViewModel.lastErrorMessage {
+                        Text(message)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onAppear {
+                    destinationConnectionViewModel.start()
+                }
+                .onDisappear {
+                    destinationConnectionViewModel.stop()
+                }
+                .onChange(of: sendLocalControlOff) {
+                    applyLocalControlOffIfNeeded()
+                }
+                .onChange(of: midiDestinationUniqueID) {
+                    applyLocalControlOffIfNeeded()
+                }
+
+                Divider()
+            }
 
             VStack(alignment: .leading, spacing: 12) {
                 Toggle("AI 即兴演奏（虚拟演奏家）", isOn: $virtualPerformerEnabled)
@@ -117,6 +186,12 @@ struct PracticeSettingsView: View {
         .frame(minWidth: 320)
     }
 
+    private func applyLocalControlOffIfNeeded() {
+        guard midiDestinationUniqueID > 0 else { return }
+        guard let destinationUniqueID = Int32(exactly: midiDestinationUniqueID) else { return }
+        destinationConnectionViewModel.sendLocalControlOff(sendLocalControlOff, destinationUniqueID: destinationUniqueID)
+    }
+
     private var effectiveBackendStatusText: String? {
         guard let selectedKind = ImprovBackendKind(rawValue: improvBackendKindRawValue) else {
             return "Backend: invalid kind"
@@ -156,8 +231,10 @@ struct PracticeSettingsView: View {
         recordingSourceText: "录制来源：Bluetooth MIDI（弹奏琴键即可录制）",
         isAIPerformanceActive: false,
         isVirtualPianoMode: true,
+        isBluetoothMIDIMode: true,
         gazePlaneDiskStatusText: "GazePlaneDisk: OK",
         onOpenTakeLibrary: {},
-        onRetryVirtualPianoPlacement: {}
+        onRetryVirtualPianoPlacement: {},
+        onRequestSessionRebuild: {}
     )
 }

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -187,7 +187,7 @@ struct PracticeSettingsView: View {
     }
 
     private func applyLocalControlOffIfNeeded() {
-        guard midiDestinationUniqueID > 0 else { return }
+        guard midiDestinationUniqueID != 0 else { return }
         guard let destinationUniqueID = Int32(exactly: midiDestinationUniqueID) else { return }
         destinationConnectionViewModel.sendLocalControlOff(sendLocalControlOff, destinationUniqueID: destinationUniqueID)
     }

--- a/LonelyPianistAVP/Views/Practice/PracticeStepView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeStepView.swift
@@ -97,7 +97,6 @@ struct PracticeStepView: View {
                 .buttonStyle(.bordered)
                 .buttonBorderShape(.roundedRectangle)
                 .hoverEffect()
-                .disabled(viewModel.isAIPerformanceActive)
                 .popover(isPresented: $isSettingsPopoverPresented) {
                     PracticeSettingsView(
                         virtualPerformerEnabled: $isVirtualPerformerEnabled,

--- a/LonelyPianistAVP/Views/Practice/PracticeStepView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeStepView.swift
@@ -106,6 +106,7 @@ struct PracticeStepView: View {
                         recordingSourceText: viewModel.recordingSourceText,
                         isAIPerformanceActive: viewModel.isAIPerformanceActive,
                         isVirtualPianoMode: isVirtualPianoMode,
+                        isBluetoothMIDIMode: viewModel.isBluetoothMIDIMode,
                         gazePlaneDiskStatusText: viewModel.gazePlaneDiskStatusText,
                         onOpenTakeLibrary: {
                             isSettingsPopoverPresented = false
@@ -113,6 +114,9 @@ struct PracticeStepView: View {
                         },
                         onRetryVirtualPianoPlacement: {
                             viewModel.retryVirtualPianoPlacement()
+                        },
+                        onRequestSessionRebuild: {
+                            viewModel.replacePracticeSessionViewModel()
                         }
                     )
                 }

--- a/LonelyPianistAVP/Views/Shared/AudioOutputVolumeRow.swift
+++ b/LonelyPianistAVP/Views/Shared/AudioOutputVolumeRow.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct AudioOutputVolumeRow: View {
+    @AppStorage(AudioOutputVolumeSettings.userDefaultsKey)
+    private var audioOutputVolume = Double(AudioOutputVolumeSettings.defaultValue)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("输出音量")
+            HStack {
+                Slider(value: $audioOutputVolume, in: 0...1)
+                Text(audioOutputVolume, format: .percent)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 56, alignment: .trailing)
+            }
+        }
+    }
+}
+

--- a/LonelyPianistAVP/Views/Shared/AudioOutputVolumeRow.swift
+++ b/LonelyPianistAVP/Views/Shared/AudioOutputVolumeRow.swift
@@ -6,7 +6,7 @@ struct AudioOutputVolumeRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("输出音量")
+            Text("输出音量（AVP）")
             HStack {
                 Slider(value: $audioOutputVolume, in: 0...1)
                 Text(audioOutputVolume, format: .percent)
@@ -14,7 +14,9 @@ struct AudioOutputVolumeRow: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 56, alignment: .trailing)
             }
+            Text("调到 0 可避免与真实钢琴叠音。")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
         }
     }
 }
-

--- a/LonelyPianistAVPTests/Audio/AudioOutputVolumeSettingsTests.swift
+++ b/LonelyPianistAVPTests/Audio/AudioOutputVolumeSettingsTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+@testable import LonelyPianistAVP
+import Testing
+
+struct AudioOutputVolumeSettingsTests {
+    @Test func defaultIsOneWhenUnset() {
+        let suiteName = "AudioOutputVolumeSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults) == 1.0)
+    }
+
+    @Test func clampsBelowZeroToZero() {
+        let suiteName = "AudioOutputVolumeSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(-0.1, forKey: AudioOutputVolumeSettings.userDefaultsKey)
+        #expect(AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults) == 0.0)
+    }
+
+    @Test func clampsAboveOneToOne() {
+        let suiteName = "AudioOutputVolumeSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(1.1, forKey: AudioOutputVolumeSettings.userDefaultsKey)
+        #expect(AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults) == 1.0)
+    }
+
+    @Test func nonFiniteFallsBackToDefault() {
+        let suiteName = "AudioOutputVolumeSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(Double.nan, forKey: AudioOutputVolumeSettings.userDefaultsKey)
+        #expect(AudioOutputVolumeSettings.readAudioOutputVolume(from: userDefaults) == 1.0)
+    }
+}
+

--- a/LonelyPianistAVPTests/MIDI/CoreMIDIPracticePlaybackServiceStopTests.swift
+++ b/LonelyPianistAVPTests/MIDI/CoreMIDIPracticePlaybackServiceStopTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+@testable import LonelyPianistAVP
+import Testing
+import os
+
+struct CoreMIDIPracticePlaybackServiceStopTests {
+    @Test func stopSendsAllNotesOffAndAllSoundOff() async throws {
+        let output = FakeMIDIOutputService()
+        let destinationUniqueID: Int32 = 1234
+        let playback = await MainActor.run {
+            CoreMIDIPracticePlaybackService(destinationUniqueID: destinationUniqueID, outputService: output, velocity: 96, channel: 0)
+        }
+
+        try await MainActor.run {
+            try playback.warmUp()
+            try playback.playOneShot(midiNotes: [60], durationSeconds: 10)
+            playback.stop()
+        }
+
+        let calls = output.callsSnapshot()
+        #expect(calls.contains(.controlChange(controller: 123, value: 0, channel: 0, destination: destinationUniqueID)))
+        #expect(calls.contains(.controlChange(controller: 120, value: 0, channel: 0, destination: destinationUniqueID)))
+    }
+}
+
+private final class FakeMIDIOutputService: MIDIOutputSendingProtocol, @unchecked Sendable {
+    enum Call: Equatable, Sendable {
+        case start
+        case stop
+        case noteOn(note: UInt8, velocity: UInt8, channel: UInt8, destination: Int32)
+        case noteOff(note: UInt8, channel: UInt8, destination: Int32)
+        case controlChange(controller: UInt8, value: UInt8, channel: UInt8, destination: Int32)
+        case programChange(program: UInt8, channel: UInt8, destination: Int32)
+        case bytes([UInt8], destination: Int32)
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: [Call]())
+
+    func callsSnapshot() -> [Call] {
+        lock.withLock { $0 }
+    }
+
+    func start() throws {
+        lock.withLock { $0.append(.start) }
+    }
+
+    func stop() {
+        lock.withLock { $0.append(.stop) }
+    }
+
+    func listDestinations() -> [MIDIDestinationInfo] { [] }
+
+    func sendMIDI1Bytes(_ bytes: [UInt8], destinationUniqueID: Int32) throws {
+        lock.withLock { $0.append(.bytes(bytes, destination: destinationUniqueID)) }
+    }
+
+    func sendNoteOn(note: UInt8, velocity: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        lock.withLock { $0.append(.noteOn(note: note, velocity: velocity, channel: channel, destination: destinationUniqueID)) }
+    }
+
+    func sendNoteOff(note: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        lock.withLock { $0.append(.noteOff(note: note, channel: channel, destination: destinationUniqueID)) }
+    }
+
+    func sendControlChange(controller: UInt8, value: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        lock.withLock { $0.append(.controlChange(controller: controller, value: value, channel: channel, destination: destinationUniqueID)) }
+    }
+
+    func sendProgramChange(program: UInt8, channel: UInt8, destinationUniqueID: Int32) throws {
+        lock.withLock { $0.append(.programChange(program: program, channel: channel, destination: destinationUniqueID)) }
+    }
+
+    func sendAllNotesOff(channel: UInt8, destinationUniqueID: Int32) throws {
+        try sendControlChange(controller: 123, value: 0, channel: channel, destinationUniqueID: destinationUniqueID)
+    }
+
+    func sendAllSoundOff(channel: UInt8, destinationUniqueID: Int32) throws {
+        try sendControlChange(controller: 120, value: 0, channel: channel, destinationUniqueID: destinationUniqueID)
+    }
+}
+

--- a/LonelyPianistAVPTests/MIDI/CoreMIDIPracticePlaybackServiceStopTests.swift
+++ b/LonelyPianistAVPTests/MIDI/CoreMIDIPracticePlaybackServiceStopTests.swift
@@ -13,7 +13,7 @@ struct CoreMIDIPracticePlaybackServiceStopTests {
 
         try await MainActor.run {
             try playback.warmUp()
-            try playback.playOneShot(midiNotes: [60], durationSeconds: 10)
+            try playback.playOneShot(noteOns: [PracticeOneShotNoteOn(midiNote: 60, velocity: 96)], durationSeconds: 10)
             playback.stop()
         }
 
@@ -78,4 +78,3 @@ private final class FakeMIDIOutputService: MIDIOutputSendingProtocol, @unchecked
         try sendControlChange(controller: 120, value: 0, channel: channel, destinationUniqueID: destinationUniqueID)
     }
 }
-

--- a/LonelyPianistAVPTests/MusicXML/MusicXMLAutoplayRegressionTests.swift
+++ b/LonelyPianistAVPTests/MusicXML/MusicXMLAutoplayRegressionTests.swift
@@ -78,7 +78,7 @@ private final class RegressionCapturingSequencerPlaybackService: PracticeSequenc
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Piano/AppModelKeyboardGeometryTests.swift
+++ b/LonelyPianistAVPTests/Piano/AppModelKeyboardGeometryTests.swift
@@ -128,7 +128,7 @@ private final class NoopSequencerPlaybackService: PracticeSequencerPlaybackServi
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/AIPerformanceCoordinatorTests.swift
+++ b/LonelyPianistAVPTests/Practice/AIPerformanceCoordinatorTests.swift
@@ -74,7 +74,7 @@ private final class FakeSequencerPlaybackService: PracticeSequencerPlaybackServi
         currentSecondsValue
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/ManualAdvanceStrategyTests.swift
+++ b/LonelyPianistAVPTests/Practice/ManualAdvanceStrategyTests.swift
@@ -140,7 +140,7 @@ private final class ManualAdvanceNoopPlaybackService: PracticeSequencerPlaybackS
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/PracticeManualReplayCoordinatorTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeManualReplayCoordinatorTests.swift
@@ -37,7 +37,7 @@ private final class FakeSequencerPlaybackService: PracticeSequencerPlaybackServi
         currentSecondsValue
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/PracticeManualReplaySequenceBuilderTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeManualReplaySequenceBuilderTests.swift
@@ -28,3 +28,30 @@ func manualReplayBuilderInsertsAllNotesOffAtEachStepStart() {
     #expect(abs(allNotesOffEvents[0].timeSeconds - 0.0) < 1e-9)
     #expect(abs(allNotesOffEvents[1].timeSeconds - 0.125) < 1e-9)
 }
+
+@Test
+func manualReplayBuilderUsesStepNoteVelocities() {
+    let tempoMap = MusicXMLTempoMap(
+        tempoEvents: [MusicXMLTempoEvent(tick: 0, quarterBPM: 120, scope: defaultTempoScope)]
+    )
+    let steps: [PracticeStep] = [
+        PracticeStep(tick: 0, notes: [
+            PracticeStepNote(midiNote: 60, staff: 1, velocity: 22),
+            PracticeStepNote(midiNote: 60, staff: 1, velocity: 88),
+            PracticeStepNote(midiNote: 64, staff: 1, velocity: 40),
+        ]),
+    ]
+
+    let builder = PracticeManualReplaySequenceBuilder(chordDurationSeconds: 0.35, velocity: 12)
+    let schedule = builder.buildSchedule(steps: steps, tempoMap: tempoMap, stepRange: 0 ..< 1)
+
+    let noteOnEvents: [(midi: Int, velocity: UInt8)] = schedule.compactMap { event in
+        if case let .noteOn(midi, velocity) = event.kind {
+            return (midi, velocity)
+        }
+        return nil
+    }
+
+    #expect(noteOnEvents.contains(where: { $0.midi == 60 && $0.velocity == 88 }))
+    #expect(noteOnEvents.contains(where: { $0.midi == 64 && $0.velocity == 40 }))
+}

--- a/LonelyPianistAVPTests/Practice/PracticePlaybackCoordinatorTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticePlaybackCoordinatorTests.swift
@@ -42,9 +42,9 @@ private final class FakeSequencerPlaybackService: PracticeSequencerPlaybackServi
         currentSecondsValue
     }
 
-    func playOneShot(midiNotes: [Int], durationSeconds _: TimeInterval) throws {
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {
         playOneShotCallCount += 1
-        lastOneShotNotes = midiNotes
+        lastOneShotNotes = noteOns.map(\.midiNote)
     }
 
     func startLiveNotes(midiNotes _: Set<Int>) throws {}

--- a/LonelyPianistAVPTests/Practice/PracticeSequencerPlaybackServiceProtocolTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSequencerPlaybackServiceProtocolTests.swift
@@ -14,7 +14,7 @@ func sequencerPlaybackServiceProtocolSupportsDependencyInjection() {
             0
         }
 
-        func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+        func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
         func startLiveNotes(midiNotes _: Set<Int>) throws {}
         func stopLiveNotes(midiNotes _: Set<Int>) {}
         func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/PracticeSessionAudioRecognitionTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSessionAudioRecognitionTests.swift
@@ -412,8 +412,8 @@ private final class CapturingSequencerPlaybackService: PracticeSequencerPlayback
         0
     }
 
-    func playOneShot(midiNotes: [Int], durationSeconds _: TimeInterval) throws {
-        oneShots.append(midiNotes)
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {
+        oneShots.append(noteOns.map(\.midiNote))
     }
 
     func startLiveNotes(midiNotes _: Set<Int>) throws {}

--- a/LonelyPianistAVPTests/Practice/PracticeSessionMIDIOnlyModeTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSessionMIDIOnlyModeTests.swift
@@ -252,7 +252,7 @@ private final class NoopPracticeSequencerPlaybackService: PracticeSequencerPlayb
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/PracticeSessionReplayGateTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSessionReplayGateTests.swift
@@ -203,7 +203,7 @@ private final class ManualReplaySequencerPlaybackService: PracticeSequencerPlayb
         currentSecondsValue
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/Practice/PracticeSessionViewModelTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSessionViewModelTests.swift
@@ -1611,8 +1611,8 @@ private final class CapturingSequencerPlaybackService: PracticeSequencerPlayback
         currentSecondsValue
     }
 
-    func playOneShot(midiNotes: [Int], durationSeconds: TimeInterval) throws {
-        oneShots.append(OneShot(midiNotes: midiNotes, durationSeconds: durationSeconds))
+    func playOneShot(noteOns: [PracticeOneShotNoteOn], durationSeconds: TimeInterval) throws {
+        oneShots.append(OneShot(midiNotes: noteOns.map(\.midiNote), durationSeconds: durationSeconds))
     }
 
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
@@ -1629,7 +1629,7 @@ private final class ThrowingSequencerPlaybackService: PracticeSequencerPlaybackS
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {
         throw PracticeAudioError.soundFontMissing(resourceName: "TestSoundFont")
     }
 

--- a/LonelyPianistAVPTests/Practice/PracticeSoundRoutingSettingsTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSoundRoutingSettingsTests.swift
@@ -29,7 +29,20 @@ struct PracticeSoundRoutingSettingsTests {
         #expect(provider.soundRoutingSettings.sendLocalControlOff)
     }
 
-    @Test func ignoresNonPositiveDestinationUniqueID() {
+    @Test func parsesNegativeDestinationUniqueID() {
+        let suiteName = "PracticeSoundRoutingSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(PracticeSoundOutputRoute.externalMIDIDestination.rawValue, forKey: PracticeSessionSettingsKeys.soundOutputRoute)
+        userDefaults.set(-1234, forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID)
+
+        let provider = UserDefaultsPracticeSessionSettingsProvider(userDefaults: userDefaults)
+        #expect(provider.soundRoutingSettings.outputRoute == .externalMIDIDestination)
+        #expect(provider.soundRoutingSettings.midiDestinationUniqueID == -1234)
+    }
+
+    @Test func ignoresZeroDestinationUniqueID() {
         let suiteName = "PracticeSoundRoutingSettingsTests.\(UUID().uuidString)"
         let userDefaults = UserDefaults(suiteName: suiteName)!
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
@@ -41,4 +54,3 @@ struct PracticeSoundRoutingSettingsTests {
         #expect(provider.soundRoutingSettings.midiDestinationUniqueID == nil)
     }
 }
-

--- a/LonelyPianistAVPTests/Practice/PracticeSoundRoutingSettingsTests.swift
+++ b/LonelyPianistAVPTests/Practice/PracticeSoundRoutingSettingsTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import LonelyPianistAVP
+import Testing
+
+struct PracticeSoundRoutingSettingsTests {
+    @Test func defaultsToLocalSampler() {
+        let suiteName = "PracticeSoundRoutingSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let provider = UserDefaultsPracticeSessionSettingsProvider(userDefaults: userDefaults)
+        #expect(provider.soundRoutingSettings.outputRoute == .localSampler)
+        #expect(provider.soundRoutingSettings.midiDestinationUniqueID == nil)
+        #expect(provider.soundRoutingSettings.sendLocalControlOff == false)
+    }
+
+    @Test func parsesExternalRouteAndDestinationUniqueID() {
+        let suiteName = "PracticeSoundRoutingSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(PracticeSoundOutputRoute.externalMIDIDestination.rawValue, forKey: PracticeSessionSettingsKeys.soundOutputRoute)
+        userDefaults.set(1234, forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID)
+        userDefaults.set(true, forKey: PracticeSessionSettingsKeys.sendLocalControlOff)
+
+        let provider = UserDefaultsPracticeSessionSettingsProvider(userDefaults: userDefaults)
+        #expect(provider.soundRoutingSettings.outputRoute == .externalMIDIDestination)
+        #expect(provider.soundRoutingSettings.midiDestinationUniqueID == 1234)
+        #expect(provider.soundRoutingSettings.sendLocalControlOff)
+    }
+
+    @Test func ignoresNonPositiveDestinationUniqueID() {
+        let suiteName = "PracticeSoundRoutingSettingsTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(PracticeSoundOutputRoute.externalMIDIDestination.rawValue, forKey: PracticeSessionSettingsKeys.soundOutputRoute)
+        userDefaults.set(0, forKey: PracticeSessionSettingsKeys.midiDestinationUniqueID)
+
+        let provider = UserDefaultsPracticeSessionSettingsProvider(userDefaults: userDefaults)
+        #expect(provider.soundRoutingSettings.midiDestinationUniqueID == nil)
+    }
+}
+

--- a/LonelyPianistAVPTests/Support/PracticeSessionViewModel+TestConvenienceInit.swift
+++ b/LonelyPianistAVPTests/Support/PracticeSessionViewModel+TestConvenienceInit.swift
@@ -42,7 +42,7 @@ private final class NoopPracticeSequencerPlaybackService: PracticeSequencerPlayb
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
     func startLiveNotes(midiNotes _: Set<Int>) throws {}
     func stopLiveNotes(midiNotes _: Set<Int>) {}
     func stopAllLiveNotes() {}

--- a/LonelyPianistAVPTests/VirtualPiano/VirtualPianoInputControllerTests.swift
+++ b/LonelyPianistAVPTests/VirtualPiano/VirtualPianoInputControllerTests.swift
@@ -63,7 +63,7 @@ private final class FakeSequencerPlaybackService: PracticeSequencerPlaybackServi
     func load(sequence _: PracticeSequencerSequence) throws {}
     func play(fromSeconds _: TimeInterval) throws {}
     func currentSeconds() -> TimeInterval { 0 }
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
 
     func startLiveNotes(midiNotes: Set<Int>) throws {
         startedLiveNotes.append(midiNotes)

--- a/LonelyPianistAVPTests/VirtualPiano/VirtualPianoTests.swift
+++ b/LonelyPianistAVPTests/VirtualPiano/VirtualPianoTests.swift
@@ -320,7 +320,7 @@ private final class LiveNoteCapturingPlaybackService: PracticeSequencerPlaybackS
         0
     }
 
-    func playOneShot(midiNotes _: [Int], durationSeconds _: TimeInterval) throws {}
+    func playOneShot(noteOns _: [PracticeOneShotNoteOn], durationSeconds _: TimeInterval) throws {}
 
     func startLiveNotes(midiNotes: Set<Int>) throws {
         startedLiveNotes.formUnion(midiNotes)

--- a/docs/GENERATION.md
+++ b/docs/GENERATION.md
@@ -4,9 +4,9 @@
 
 | Item | Value |
 | --- | --- |
-| Commit hash | e50d88b |
+| Commit hash | e07275f4 |
 | Branch name | crh2 |
-| Generated at | 2026-05-23T02:25:20+08:00 |
+| Generated at | 2026-05-23T11:01:47+08:00 |
 | Output language | Chinese |
 | Generation mode | Full docs reconciliation via `neat-freak` against current working tree |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,17 @@
 
 `PracticeSessionSettingsProvider` 使用 `UserDefaults` 保存练习相关设置；修改时优先从 provider 和对应 UI 查找真实 key。
 
+### 练习发声路由与音量（AVP）
+
+以下键值由 `UserDefaultsPracticeSessionSettingsProvider` 与练习设置 UI 共同维护（以代码为准）：
+
+| Key | 说明 |
+| --- | --- |
+| `practiceSoundOutputRoute` | 发声路由：`localSampler`（仅 AVP 发声）或 `externalMIDIDestination`（仅真实钢琴发声）。 |
+| `practiceMIDIDestinationUniqueID` | 外部 MIDI 输出目的地的 `kMIDIPropertyUniqueID`（`Int32`，可能为负数；`0` 表示未选择）。 |
+| `practiceSendLocalControlOff` | 是否 best-effort 向目的地发送 Local Control Off（CC122）。兼容性不保证，默认关闭。 |
+| `AudioOutputVolumeSettings.userDefaultsKey` | AVP 本地采样器输出音量（0…1）。仅影响 AVP sampler，不影响外部 MIDI 发往真实钢琴的力度/音量。 |
+
 说明（练习判定与设置项）：
 - “练习判定：左右手分别满足”已改为强制启用（不再作为可配置项，也不再暴露 UI 开关）。
 - 当前仍会通过 `UserDefaults` 保存练习手（左/右/双手）、手动推进方式与音频识别模式等设置项。

--- a/docs/modules/lonelypianist-avp-practice.md
+++ b/docs/modules/lonelypianist-avp-practice.md
@@ -66,6 +66,13 @@ flowchart TD
 
 启动自动播放前必须具备 pedal timeline、fermata timeline、highlight guides 和严格 trigger guide index。缺失时返回中文错误消息并阻止启动。
 
+## 回放与发声路由（蓝牙 MIDI）
+
+练习回放通过 `PracticeSequencerPlaybackServiceProtocol` 抽象输出；在蓝牙 MIDI 模式下会根据用户设置切换实现：
+
+- `AVAudioSequencerPracticePlaybackService`：本地 sampler（仅 AVP 发声，受 AVP 输出音量影响）。
+- `CoreMIDIPracticePlaybackService`：外部 MIDI destination（仅真实钢琴发声，音量/力度由 MIDI velocity 与钢琴自身响应决定）。
+
 ## 录制与 take library
 
 | 代码 | 说明 |

--- a/docs/modules/lonelypianist-avp.md
+++ b/docs/modules/lonelypianist-avp.md
@@ -24,6 +24,13 @@
 
 模式注册由 `PianoModeCatalogService.makeDefaultModes()` 与 `PianoModeRegistryService` 完成。
 
+### 蓝牙 MIDI 模式的发声路由
+
+当选择“真实钢琴（蓝牙 MIDI）”时，练习回放支持两种路由：
+
+- 仅 AVP 发声：使用 AVP 内置 sampler（音量由练习设置里的“输出音量（AVP）”控制）。
+- 仅真实钢琴发声：把回放事件通过 CoreMIDI 发送到用户选择的 MIDI destination（`kMIDIPropertyUniqueID` 可能为负数；`0` 表示未选择）。
+
 ## 准备阶段 UI
 
 | 代码 | 说明 |


### PR DESCRIPTION
## 背景
- 蓝牙 MIDI 模式的练习会话固定使用本地 sampler 播放（`AVAudioSequencerPracticePlaybackService`），因此自动播放/提示音无法输出到指定 CoreMIDI 目的地。
- `PracticeSequencerSequence` 只提供导出的 MIDI Data，缺少可直接调度的事件序列，导致无法在不解析 MIDI 文件的前提下实现“按时间发送到 CoreMIDI”的播放实现。
- AVP 输出音量缺少可持久化的统一入口，练习播放与曲库预览只能沿用系统默认音量，叠音场景下难以单独调低。

## 变更
### 蓝牙 MIDI 发声路由与目的地
- 改了什么：新增 `PracticeSoundOutputRoute`/`PracticeSoundRoutingSettings`，并在 `UserDefaultsPracticeSessionSettingsProvider.soundRoutingSettings` 解析 `practiceSoundOutputRoute`/`practiceMIDIDestinationUniqueID`/`practiceSendLocalControlOff`；练习设置与蓝牙准备页提供路由与目的地选择，并通过 `replacePracticeSessionViewModel()` 应用。
- 为什么这样改：旧实现无法表达“仅真实钢琴发声/仅 AVP 发声”的路由意图，也无法在会话构建后把设置变更落到实际 playback 实例。
- 关键实现细节：`.bluetoothMIDI` 会话创建时按 route 在本地 sampler 与外部 MIDI 播放实现之间切换；未选择目的地时回退本地 sampler，并把 settingsProvider 注入会话以保持读取一致。

### CoreMIDI 输出播放
- 改了什么：新增 `CoreMIDIOutputService`（枚举目的地、按 uniqueID 缓存 endpoint、发送 MIDI1 bytes/常用消息）与 `CoreMIDIPracticePlaybackService`（实现 `PracticeSequencerPlaybackServiceProtocol`，把 `PracticeSequencerSequence.events` 定时发送到目的地），并支持 one-shot 与 live notes。
- 为什么这样改：`AVAudioSequencer` 只能驱动本机音频单元，无法把练习/自动播放的事件送到 CoreMIDI 目的地。
- 关键实现细节：`PracticeSequencerSequenceBuilder.buildSequence` 额外返回按时间排序的 `events`；`MIDIEventScheduler` actor 以 `systemUptime` 为基准计算等待并 `Task.sleep(for:)` 调度发送；`stop()` 取消调度任务并对已触发的音符发送 NoteOff，最后 best-effort 发送 CC123/CC120 兜底静音。

### AVP 输出音量统一设置
- 改了什么：新增 `AudioOutputVolumeSettings`（`audioOutputVolume`，0...1 clamp）并让 `AVAudioSequencerPracticePlaybackService` 与 `SongAudioPlayer` 在播放前/设置变更时应用；曲库页新增“音量”弹窗（`AudioOutputVolumeRow`），练习设置页直接内嵌滑杆。
- 为什么这样改：旧实现练习播放与曲库预览无法共享同一套持久音量控制，用户难以在“真实钢琴叠音”场景下快速把 AVP 音量压到合适水平。
- 关键实现细节：服务端缓存 `currentAudioOutputVolume` 避免重复写入；通过监听 `UserDefaults.didChangeNotification` 实时更新。

## 测试
- 运行 `xcodebuild test -project LonelyPianist.xcodeproj -scheme LonelyPianistAVP -destination 'platform=visionOS Simulator,name=Apple Vision Pro'`，期望全部测试通过。
- 在蓝牙 MIDI 模式进入练习设置，把“发声路由”切到“仅真实钢琴发声”，选择一个“MIDI 输出目的地”并点“应用路由变更并重启会话”，期望后续提示音/自动播放从所选目的地输出且 AVP sampler 不再发声。
- 在曲库页点“音量”调整到 0 再播放音频预览，期望预览静音；把音量调回 50% 再播放，期望预览音量同步变化。
- 在已选择目的地时切换“Local Control Off（可选）”，期望对目的地 best-effort 发送 CC122（0/127）且 UI 不出现错误提示。
