### PR TITLE
接入本地CoreML即兴

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ __pycache__/
 *.mag
 *.mlpackage
 *.mlmodel
+*.mlmodelc
+LonelyPianistAVP/Resources/Models/

--- a/LonelyPianist.xcodeproj/project.pbxproj
+++ b/LonelyPianist.xcodeproj/project.pbxproj
@@ -36,10 +36,10 @@
 /* Begin PBXFileReference section */
 		1B62407901B3CFC1E2FBC10D /* ImprovEngines */ = {isa = PBXFileReference; lastKnownFileType = text; path = ImprovEngines; sourceTree = "<group>"; };
 		D85596AC2F83FF72005BE7FE /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = text; path = RealityKitContent; sourceTree = "<group>"; };
-		D8EA41B62F978A340059B709 /* LonelyPianistAVP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = LonelyPianistAVP.app; path = "/Users/chii_magnus/Github_OpenSource/LonelyPianist/build/Debug-xros/LonelyPianistAVP.app"; sourceTree = "<absolute>"; };
-		D8EA41B72F978A340059B709 /* LonelyPianist.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = LonelyPianist.app; path = /Users/chii_magnus/Github_OpenSource/LonelyPianist/build/Debug/LonelyPianist.app; sourceTree = "<absolute>"; };
-		D8EA41B82F978A340059B709 /* LonelyPianistTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = LonelyPianistTests.xctest; path = /Users/chii_magnus/Github_OpenSource/LonelyPianist/build/Debug/LonelyPianistTests.xctest; sourceTree = "<absolute>"; };
-		D8EA41B92F978A340059B709 /* LonelyPianistAVPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = LonelyPianistAVPTests.xctest; path = "/Users/chii_magnus/Github_OpenSource/LonelyPianist/build/Debug-xros/LonelyPianistAVP.app/PlugIns/LonelyPianistAVPTests.xctest"; sourceTree = "<absolute>"; };
+		D8C8848C2FC3623C00F1D94F /* LonelyPianist.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LonelyPianist.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8C8848D2FC3623C00F1D94F /* LonelyPianistAVP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LonelyPianistAVP.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8C8848E2FC3623C00F1D94F /* LonelyPianistTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LonelyPianistTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8C8848F2FC3623C00F1D94F /* LonelyPianistAVPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LonelyPianistAVPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -144,6 +144,10 @@
 				D85596AA2F83FF72005BE7FE /* LonelyPianistAVP */,
 				D85596AB2F83FF72005BE7FE /* Packages */,
 				D85596BF2F83FF74005BE7FE /* LonelyPianistAVPTests */,
+				D8C8848C2FC3623C00F1D94F /* LonelyPianist.app */,
+				D8C8848D2FC3623C00F1D94F /* LonelyPianistAVP.app */,
+				D8C8848E2FC3623C00F1D94F /* LonelyPianistTests.xctest */,
+				D8C8848F2FC3623C00F1D94F /* LonelyPianistAVPTests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
@@ -173,7 +177,7 @@
 				83545B10812945C78780DB2C /* ZIPFoundation */,
 			);
 			productName = LonelyPianistAVP;
-			productReference = D8EA41B62F978A340059B709 /* LonelyPianistAVP.app */;
+			productReference = D8C8848D2FC3623C00F1D94F /* LonelyPianistAVP.app */;
 			productType = "com.apple.product-type.application";
 		};
 		D85596BB2F83FF74005BE7FE /* LonelyPianistAVPTests */ = {
@@ -199,7 +203,7 @@
 				83545B10812945C78780DB2C /* ZIPFoundation */,
 			);
 			productName = LonelyPianistAVPTests;
-			productReference = D8EA41B92F978A340059B709 /* LonelyPianistAVPTests.xctest */;
+			productReference = D8C8848F2FC3623C00F1D94F /* LonelyPianistAVPTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		D8D4280C2F4DFD3800EC9C9B /* LonelyPianist */ = {
@@ -221,7 +225,7 @@
 			packageProductDependencies = (
 			);
 			productName = LonelyPianist;
-			productReference = D8EA41B72F978A340059B709 /* LonelyPianist.app */;
+			productReference = D8C8848C2FC3623C00F1D94F /* LonelyPianist.app */;
 			productType = "com.apple.product-type.application";
 		};
 		E10000012A9B000100000006 /* LonelyPianistTests */ = {
@@ -244,7 +248,7 @@
 			packageProductDependencies = (
 			);
 			productName = LonelyPianistTests;
-			productReference = D8EA41B82F978A340059B709 /* LonelyPianistTests.xctest */;
+			productReference = D8C8848E2FC3623C00F1D94F /* LonelyPianistTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/CoreMLPerformanceRNNStepModel.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/CoreMLPerformanceRNNStepModel.swift
@@ -1,0 +1,146 @@
+@preconcurrency import CoreML
+import Foundation
+
+actor CoreMLPerformanceRNNStepModel: PerformanceRNNStepModeling {
+    private let model: MLModel
+
+    init(model: MLModel) {
+        self.model = model
+    }
+
+    func step(eventID: Int, temperature: Float, state: PerformanceRNNState) async throws -> PerformanceRNNStepResult {
+        guard (0 ..< PerformanceRNNEventCodec.numClasses).contains(eventID) else {
+            throw PerformanceRNNStepModelError.invalidEventID(expectedRange: 0 ... (PerformanceRNNEventCodec.numClasses - 1), actual: eventID)
+        }
+
+        do {
+            let x = try oneHotEventInput(eventID: eventID)
+            let temperatureInput = try scalarInput(value: temperature)
+            let c0 = try vectorInput(values: state.c0)
+            let h0 = try vectorInput(values: state.h0)
+            let c1 = try vectorInput(values: state.c1)
+            let h1 = try vectorInput(values: state.h1)
+            let c2 = try vectorInput(values: state.c2)
+            let h2 = try vectorInput(values: state.h2)
+
+            let provider = try MLDictionaryFeatureProvider(
+                dictionary: [
+                    "x": MLFeatureValue(multiArray: x),
+                    "temperature": MLFeatureValue(multiArray: temperatureInput),
+                    "c0": MLFeatureValue(multiArray: c0),
+                    "h0": MLFeatureValue(multiArray: h0),
+                    "c1": MLFeatureValue(multiArray: c1),
+                    "h1": MLFeatureValue(multiArray: h1),
+                    "c2": MLFeatureValue(multiArray: c2),
+                    "h2": MLFeatureValue(multiArray: h2),
+                ]
+            )
+
+            let model = self.model
+            let output = try await model.prediction(from: provider)
+
+            let softmax = try float32Array(output, name: "softmax", expectedCount: PerformanceRNNEventCodec.numClasses)
+            let nextState = try PerformanceRNNState(
+                c0: float32Array(output, name: "c0_out", expectedCount: PerformanceRNNState.hiddenSize),
+                h0: float32Array(output, name: "h0_out", expectedCount: PerformanceRNNState.hiddenSize),
+                c1: float32Array(output, name: "c1_out", expectedCount: PerformanceRNNState.hiddenSize),
+                h1: float32Array(output, name: "h1_out", expectedCount: PerformanceRNNState.hiddenSize),
+                c2: float32Array(output, name: "c2_out", expectedCount: PerformanceRNNState.hiddenSize),
+                h2: float32Array(output, name: "h2_out", expectedCount: PerformanceRNNState.hiddenSize)
+            )
+            return try PerformanceRNNStepResult(softmax: softmax, state: nextState)
+        } catch let error as PerformanceRNNStepModelError {
+            throw error
+        } catch {
+            throw PerformanceRNNStepModelError.coreMLPredictionFailed(message: String(describing: error))
+        }
+    }
+
+    private func oneHotEventInput(eventID: Int) throws -> MLMultiArray {
+        let multiArray = try MLMultiArray(
+            shape: [
+                NSNumber(value: 1),
+                NSNumber(value: 1),
+                NSNumber(value: PerformanceRNNEventCodec.numClasses),
+            ],
+            dataType: .float32
+        )
+        multiArray.resetToZeros()
+        let ptr = multiArray.dataPointer.assumingMemoryBound(to: Float32.self)
+        ptr[eventID] = 1
+        return multiArray
+    }
+
+    private func scalarInput(value: Float) throws -> MLMultiArray {
+        let multiArray = try MLMultiArray(
+            shape: [
+                NSNumber(value: 1),
+                NSNumber(value: 1),
+            ],
+            dataType: .float32
+        )
+        let ptr = multiArray.dataPointer.assumingMemoryBound(to: Float32.self)
+        ptr[0] = Float32(value)
+        return multiArray
+    }
+
+    private func vectorInput(values: [Float]) throws -> MLMultiArray {
+        guard values.count == PerformanceRNNState.hiddenSize else {
+            throw PerformanceRNNStepModelError.invalidStateVector(
+                name: "vector",
+                expectedCount: PerformanceRNNState.hiddenSize,
+                actualCount: values.count
+            )
+        }
+
+        let multiArray = try MLMultiArray(
+            shape: [
+                NSNumber(value: 1),
+                NSNumber(value: PerformanceRNNState.hiddenSize),
+            ],
+            dataType: .float32
+        )
+        let ptr = multiArray.dataPointer.assumingMemoryBound(to: Float32.self)
+        for i in 0 ..< values.count {
+            ptr[i] = Float32(values[i])
+        }
+        return multiArray
+    }
+
+    private func float32Array(_ provider: MLFeatureProvider, name: String, expectedCount: Int) throws -> [Float] {
+        guard let multiArray = provider.featureValue(for: name)?.multiArrayValue else {
+            throw PerformanceRNNStepModelError.coreMLMissingOutput(name: name)
+        }
+
+        let count = multiArray.count
+        guard count == expectedCount else {
+            throw PerformanceRNNStepModelError.coreMLInvalidOutputShape(name: name, expectedCount: expectedCount, actualCount: count)
+        }
+
+        let ptr = multiArray.dataPointer.assumingMemoryBound(to: Float32.self)
+        var values: [Float] = []
+        values.reserveCapacity(count)
+        for i in 0 ..< count {
+            values.append(Float(ptr[i]))
+        }
+        return values
+    }
+}
+
+private extension MLMultiArray {
+    func resetToZeros() {
+        let count = self.count
+        switch dataType {
+        case .float32:
+            let ptr = dataPointer.assumingMemoryBound(to: Float32.self)
+            ptr.update(repeating: 0, count: count)
+        case .double:
+            let ptr = dataPointer.assumingMemoryBound(to: Double.self)
+            ptr.update(repeating: 0, count: count)
+        default:
+            for i in 0 ..< count {
+                self[i] = 0
+            }
+        }
+    }
+}

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNCoreMLModelLoader.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNCoreMLModelLoader.swift
@@ -16,6 +16,16 @@ enum PerformanceRNNCoreMLModelLoaderError: Error, LocalizedError, Equatable, Sen
             "CoreML load failed (\(modelName)): \(message)"
         }
     }
+
+    static func sanitizeMessage(_ message: String) -> String {
+        var sanitized = message
+        let home = NSHomeDirectory()
+        if home.isEmpty == false {
+            sanitized = sanitized.replacingOccurrences(of: home, with: "~")
+        }
+        sanitized = sanitized.replacingOccurrences(of: "file://", with: "")
+        return sanitized
+    }
 }
 
 protocol PerformanceRNNCoreMLModelLoading: Sendable {
@@ -57,7 +67,7 @@ actor PerformanceRNNCoreMLModelLoader: PerformanceRNNCoreMLModelLoading {
         } catch {
             throw PerformanceRNNCoreMLModelLoaderError.loadFailed(
                 modelName: "\(Self.modelBaseName).\(Self.compiledExtension)",
-                message: String(describing: error)
+                message: PerformanceRNNCoreMLModelLoaderError.sanitizeMessage(String(describing: error))
             )
         }
     }
@@ -82,7 +92,7 @@ actor PerformanceRNNCoreMLModelLoader: PerformanceRNNCoreMLModelLoading {
         } catch {
             throw PerformanceRNNCoreMLModelLoaderError.compileFailed(
                 modelName: "\(Self.modelBaseName).\(Self.packageExtension)",
-                message: String(describing: error)
+                message: PerformanceRNNCoreMLModelLoaderError.sanitizeMessage(String(describing: error))
             )
         }
     }

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNCoreMLModelLoader.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNCoreMLModelLoader.swift
@@ -1,0 +1,107 @@
+@preconcurrency import CoreML
+import Foundation
+
+enum PerformanceRNNCoreMLModelLoaderError: Error, LocalizedError, Equatable, Sendable {
+    case modelMissing(expectedNames: [String])
+    case compileFailed(modelName: String, message: String)
+    case loadFailed(modelName: String, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .modelMissing(expectedNames):
+            "CoreML model is missing. Expected one of: \(expectedNames.joined(separator: ", "))."
+        case let .compileFailed(modelName, message):
+            "CoreML compile failed (\(modelName)): \(message)"
+        case let .loadFailed(modelName, message):
+            "CoreML load failed (\(modelName)): \(message)"
+        }
+    }
+}
+
+protocol PerformanceRNNCoreMLModelLoading: Sendable {
+    func loadStepModel() async throws -> any PerformanceRNNStepModeling
+}
+
+actor PerformanceRNNCoreMLModelLoader: PerformanceRNNCoreMLModelLoading {
+    private static let modelBaseName = "AIDuetPerformanceRNN"
+    private static let compiledExtension = "mlmodelc"
+    private static let packageExtension = "mlpackage"
+
+    private let bundle: Bundle
+    private let fileManager: FileManager
+    private let configuration: MLModelConfiguration
+
+    private var cachedStepModel: CoreMLPerformanceRNNStepModel?
+
+    init(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default,
+        configuration: MLModelConfiguration = MLModelConfiguration()
+    ) {
+        self.bundle = bundle
+        self.fileManager = fileManager
+        self.configuration = configuration
+    }
+
+    func loadStepModel() async throws -> any PerformanceRNNStepModeling {
+        if let cachedStepModel {
+            return cachedStepModel
+        }
+
+        let modelURL = try resolveCompiledModelURL()
+        do {
+            let model = try await MLModel.load(contentsOf: modelURL, configuration: configuration)
+            let stepModel = CoreMLPerformanceRNNStepModel(model: model)
+            cachedStepModel = stepModel
+            return stepModel
+        } catch {
+            throw PerformanceRNNCoreMLModelLoaderError.loadFailed(
+                modelName: "\(Self.modelBaseName).\(Self.compiledExtension)",
+                message: String(describing: error)
+            )
+        }
+    }
+
+    private func resolveCompiledModelURL() throws -> URL {
+        if let compiledInBundle = bundle.url(forResource: Self.modelBaseName, withExtension: Self.compiledExtension) {
+            return compiledInBundle
+        }
+
+        guard let packageInBundle = bundle.url(forResource: Self.modelBaseName, withExtension: Self.packageExtension) else {
+            throw PerformanceRNNCoreMLModelLoaderError.modelMissing(
+                expectedNames: [
+                    "\(Self.modelBaseName).\(Self.compiledExtension)",
+                    "\(Self.modelBaseName).\(Self.packageExtension)",
+                ]
+            )
+        }
+
+        do {
+            let compiledURL = try MLModel.compileModel(at: packageInBundle)
+            return bestEffortCacheCompiledModel(compiledURL: compiledURL) ?? compiledURL
+        } catch {
+            throw PerformanceRNNCoreMLModelLoaderError.compileFailed(
+                modelName: "\(Self.modelBaseName).\(Self.packageExtension)",
+                message: String(describing: error)
+            )
+        }
+    }
+
+    private func bestEffortCacheCompiledModel(compiledURL: URL) -> URL? {
+        guard let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+
+        let cacheURL = cachesDirectory.appending(path: "\(Self.modelBaseName).\(Self.compiledExtension)")
+
+        do {
+            if fileManager.fileExists(atPath: cacheURL.path()) {
+                try fileManager.removeItem(at: cacheURL)
+            }
+            try fileManager.copyItem(at: compiledURL, to: cacheURL)
+            return cacheURL
+        } catch {
+            return nil
+        }
+    }
+}

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
@@ -147,7 +147,7 @@ struct PerformanceRNNEventCodec: Sendable {
             let velocityBin = Self.velocityToBin(note.velocity)
 
             let startStep = Self.quantizedStep(seconds: note.time)
-            let endStep = Self.quantizedStep(seconds: note.time + note.duration)
+            let endStep = max(startStep + 1, Self.quantizedStep(seconds: note.time + note.duration))
 
             events.append(.init(step: startStep, pitch: pitch, kind: .noteOn(velocityBin: velocityBin)))
             events.append(.init(step: endStep, pitch: pitch, kind: .noteOff))

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
@@ -44,6 +44,78 @@ struct PerformanceRNNEventCodec: Sendable {
         return eventIDs
     }
 
+    func decode(eventIDs: [Int], promptEndTimeSeconds: Double) -> [ImprovDialogueNote] {
+        var currentStep = 0
+        var currentVelocity = 90
+
+        struct OpenNote: Sendable {
+            let startStep: Int
+            let velocity: Int
+        }
+        var openNotes: [Int: OpenNote] = [:]
+
+        var decoded: [ImprovDialogueNote] = []
+        decoded.reserveCapacity(eventIDs.count / 2)
+
+        func closeNote(pitch: Int, endStep: Int) {
+            guard let open = openNotes.removeValue(forKey: pitch) else { return }
+            appendNote(pitch: pitch, velocity: open.velocity, startStep: open.startStep, endStep: endStep)
+        }
+
+        func appendNote(pitch: Int, velocity: Int, startStep: Int, endStep: Int) {
+            let clampedPitch = max(21, min(108, pitch))
+            let clampedVelocity = max(1, min(127, velocity))
+
+            let absStart = Double(startStep) / Double(Self.stepsPerSecond)
+            let absEnd = Double(max(endStep, startStep)) / Double(Self.stepsPerSecond)
+
+            let clippedStart = max(absStart, promptEndTimeSeconds)
+            let clippedEnd = absEnd
+            guard clippedEnd > clippedStart else { return }
+
+            let time = clippedStart - promptEndTimeSeconds
+            let duration = max(0.01, clippedEnd - clippedStart)
+            decoded.append(ImprovDialogueNote(note: clampedPitch, velocity: clampedVelocity, time: time, duration: duration))
+        }
+
+        for eventID in eventIDs {
+            switch eventID {
+            case 0 ... 127: // NOTE_ON
+                let pitch = eventID
+                if openNotes[pitch] != nil {
+                    closeNote(pitch: pitch, endStep: currentStep)
+                }
+                openNotes[pitch] = OpenNote(startStep: currentStep, velocity: currentVelocity)
+
+            case 128 ... 255: // NOTE_OFF
+                let pitch = eventID - 128
+                closeNote(pitch: pitch, endStep: currentStep)
+
+            case 256 ... 355: // TIME_SHIFT
+                currentStep += (eventID - 255)
+
+            case 356 ... 387: // VELOCITY
+                let bin = eventID - 355
+                currentVelocity = Self.binToVelocity(bin)
+
+            default:
+                continue
+            }
+        }
+
+        // Settle remaining open notes with a max duration cap to avoid infinite sustain.
+        let maxDurationSteps = 5 * Self.stepsPerSecond
+        for (pitch, open) in openNotes {
+            let endStep = max(open.startStep + 1, min(open.startStep + maxDurationSteps, currentStep))
+            appendNote(pitch: pitch, velocity: open.velocity, startStep: open.startStep, endStep: endStep)
+        }
+
+        return decoded.sorted { lhs, rhs in
+            if lhs.time != rhs.time { return lhs.time < rhs.time }
+            return lhs.note < rhs.note
+        }
+    }
+
     static func velocityToBin(_ velocity: Int) -> Int {
         let clampedVelocity = max(1, min(127, velocity))
         let zeroBased = (clampedVelocity - 1) / velocityBinSize
@@ -136,4 +208,3 @@ struct PerformanceRNNEventCodec: Sendable {
         355 + max(1, min(numVelocityBins, bin))
     }
 }
-

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNEventCodec.swift
@@ -1,0 +1,139 @@
+import Foundation
+import ImprovProtocol
+
+/// Performance RNN event codec (Magenta / note-seq compatible).
+///
+/// Vocabulary (numClasses=388):
+/// - NOTE_ON(pitch 0..127) -> 0..127
+/// - NOTE_OFF(pitch 0..127) -> 128..255
+/// - TIME_SHIFT(steps 1..100) -> 256..355
+/// - VELOCITY(bin 1..32) -> 356..387
+struct PerformanceRNNEventCodec: Sendable {
+    static let numClasses = 388
+    static let stepsPerSecond = 100
+    static let numVelocityBins = 32
+    static let velocityBinSize = 4
+
+    init() {}
+
+    func encode(notes: [ImprovDialogueNote]) -> [Int] {
+        let edgeEvents = collectNoteEdgeEvents(notes: notes)
+        guard edgeEvents.isEmpty == false else { return [] }
+
+        var currentStep = 0
+        var currentVelocityBin: Int?
+        var eventIDs: [Int] = []
+        eventIDs.reserveCapacity(edgeEvents.count * 2)
+
+        for event in edgeEvents {
+            emitTimeShiftIfNeeded(from: currentStep, to: event.step, eventIDs: &eventIDs)
+            currentStep = event.step
+
+            switch event.kind {
+            case .noteOff:
+                eventIDs.append(Self.noteOffEventID(pitch: event.pitch))
+            case let .noteOn(velocityBin):
+                if currentVelocityBin != velocityBin {
+                    eventIDs.append(Self.velocityEventID(bin: velocityBin))
+                    currentVelocityBin = velocityBin
+                }
+                eventIDs.append(Self.noteOnEventID(pitch: event.pitch))
+            }
+        }
+
+        return eventIDs
+    }
+
+    static func velocityToBin(_ velocity: Int) -> Int {
+        let clampedVelocity = max(1, min(127, velocity))
+        let zeroBased = (clampedVelocity - 1) / velocityBinSize
+        return max(1, min(numVelocityBins, zeroBased + 1))
+    }
+
+    static func binToVelocity(_ bin: Int) -> Int {
+        let clampedBin = max(1, min(numVelocityBins, bin))
+        return 1 + (clampedBin - 1) * velocityBinSize
+    }
+
+    private enum NoteEdgeKind: Sendable, Hashable {
+        case noteOff
+        case noteOn(velocityBin: Int)
+    }
+
+    private struct NoteEdgeEvent: Sendable, Hashable {
+        let step: Int
+        let pitch: Int
+        let kind: NoteEdgeKind
+    }
+
+    private func collectNoteEdgeEvents(notes: [ImprovDialogueNote]) -> [NoteEdgeEvent] {
+        var events: [NoteEdgeEvent] = []
+        events.reserveCapacity(notes.count * 2)
+
+        for note in notes {
+            let pitch = max(0, min(127, note.note))
+            let velocityBin = Self.velocityToBin(note.velocity)
+
+            let startStep = Self.quantizedStep(seconds: note.time)
+            let endStep = Self.quantizedStep(seconds: note.time + note.duration)
+
+            events.append(.init(step: startStep, pitch: pitch, kind: .noteOn(velocityBin: velocityBin)))
+            events.append(.init(step: endStep, pitch: pitch, kind: .noteOff))
+        }
+
+        // Ordering rules (note-seq / MIDI convention):
+        // - Primary: step ascending
+        // - Same step: NOTE_OFF before NOTE_ON (stable retrigger)
+        // - Same kind: pitch ascending (stable chord encoding)
+        events.sort { lhs, rhs in
+            if lhs.step != rhs.step { return lhs.step < rhs.step }
+            let lhsPriority = kindPriority(lhs.kind)
+            let rhsPriority = kindPriority(rhs.kind)
+            if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+            return lhs.pitch < rhs.pitch
+        }
+
+        return events
+    }
+
+    private func kindPriority(_ kind: NoteEdgeKind) -> Int {
+        switch kind {
+        case .noteOff:
+            return 0
+        case .noteOn:
+            return 1
+        }
+    }
+
+    private func emitTimeShiftIfNeeded(from currentStep: Int, to targetStep: Int, eventIDs: inout [Int]) {
+        guard targetStep > currentStep else { return }
+        var remaining = targetStep - currentStep
+        while remaining > 0 {
+            let chunk = min(remaining, 100)
+            eventIDs.append(Self.timeShiftEventID(steps: chunk))
+            remaining -= chunk
+        }
+    }
+
+    private static func quantizedStep(seconds: Double) -> Int {
+        let clampedSeconds = max(0, seconds)
+        return Int(clampedSeconds * Double(stepsPerSecond) + 0.5)
+    }
+
+    private static func noteOnEventID(pitch: Int) -> Int {
+        max(0, min(127, pitch))
+    }
+
+    private static func noteOffEventID(pitch: Int) -> Int {
+        128 + max(0, min(127, pitch))
+    }
+
+    private static func timeShiftEventID(steps: Int) -> Int {
+        255 + max(1, min(100, steps))
+    }
+
+    private static func velocityEventID(bin: Int) -> Int {
+        355 + max(1, min(numVelocityBins, bin))
+    }
+}
+

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNImprovGenerator.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNImprovGenerator.swift
@@ -1,0 +1,155 @@
+import Foundation
+import ImprovEngines
+import ImprovProtocol
+
+enum PerformanceRNNImprovGeneratorError: Error, LocalizedError, Equatable, Sendable {
+    case emptyPrompt
+    case invalidDistribution
+    case generationLimitExceeded
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyPrompt:
+            "Prompt is empty."
+        case .invalidDistribution:
+            "Model returned an invalid probability distribution."
+        case .generationLimitExceeded:
+            "Generation limit exceeded."
+        }
+    }
+}
+
+struct PerformanceRNNImprovGenerator: Sendable {
+    private let codec: PerformanceRNNEventCodec
+    private let seedResolver: ImprovSeedResolver
+
+    init(codec: PerformanceRNNEventCodec = PerformanceRNNEventCodec(), seedResolver: ImprovSeedResolver = ImprovSeedResolver()) {
+        self.codec = codec
+        self.seedResolver = seedResolver
+    }
+
+    func temperatureFromTopP(_ topP: Double) -> Float {
+        let p = max(0.0, min(1.0, topP))
+        let t: Double
+        if p <= 0.7 {
+            t = 0.0
+        } else if p >= 1.0 {
+            t = 1.0
+        } else {
+            t = (p - 0.7) / 0.3
+        }
+        let temperature = 0.8 + (1.2 - 0.8) * t
+        return Float(max(0.5, min(1.5, temperature)))
+    }
+
+    func replyLenSecondsFromMaxTokens(_ maxTokens: Int) -> Double {
+        let seconds = Double(max(0, maxTokens)) / 64.0
+        return max(2.0, min(12.0, seconds))
+    }
+
+    func generateReplyNotes<StepModel: PerformanceRNNStepModeling>(
+        promptNotes: [ImprovDialogueNote],
+        params: ImprovGenerateParams,
+        sessionID: String?,
+        stepModel: StepModel
+    ) async throws -> [ImprovDialogueNote] {
+        guard promptNotes.isEmpty == false else {
+            throw PerformanceRNNImprovGeneratorError.emptyPrompt
+        }
+
+        let temperature = temperatureFromTopP(params.topP)
+        let promptEndTimeSeconds = promptNotes.map { $0.time + $0.duration }.max() ?? 0.0
+        let promptEndStep = Int(promptEndTimeSeconds * 100.0 + 0.5)
+
+        let replyLenSec = replyLenSecondsFromMaxTokens(params.maxTokens)
+        let targetEndStep = promptEndStep + Int(replyLenSec * 100.0 + 0.5)
+
+        let seed = seedResolver.resolveSeed(explicitSeed: params.seed, sessionID: sessionID)
+        var rng = PythonRandom(seed: seed)
+
+        var eventStream = codec.encode(notes: promptNotes)
+        var state = PerformanceRNNState.zeros()
+        var currentStep = 0
+
+        for eventID in eventStream {
+            try Task.checkCancellation()
+            let stepResult = try await stepModel.step(eventID: eventID, temperature: temperature, state: state)
+            state = stepResult.state
+            if (256 ... 355).contains(eventID) {
+                currentStep += (eventID - 255)
+            }
+        }
+
+        // Ensure reply begins with an explicit VELOCITY event, so decoder doesn't rely on a default.
+        let defaultVelocity: Int = {
+            let velocities = promptNotes.map(\.velocity).filter { $0 > 0 }
+            if velocities.isEmpty { return 80 }
+            return max(1, min(127, Int(Double(velocities.reduce(0, +)) / Double(velocities.count))))
+        }()
+        let velocityBin = PerformanceRNNEventCodec.velocityToBin(defaultVelocity)
+        let velocityEventID = 355 + velocityBin
+        if eventStream.last != velocityEventID {
+            try Task.checkCancellation()
+            let stepResult = try await stepModel.step(eventID: velocityEventID, temperature: temperature, state: state)
+            state = stepResult.state
+            eventStream.append(velocityEventID)
+        }
+
+        guard let initialLastEventID = eventStream.last else {
+            throw PerformanceRNNImprovGeneratorError.emptyPrompt
+        }
+        var lastEventID = initialLastEventID
+        let maxGeneratedEvents = max(2048, params.maxTokens * 32)
+        var generatedCount = 0
+
+        while currentStep < targetEndStep {
+            try Task.checkCancellation()
+            if generatedCount >= maxGeneratedEvents {
+                throw PerformanceRNNImprovGeneratorError.generationLimitExceeded
+            }
+
+            let stepResult = try await stepModel.step(eventID: lastEventID, temperature: temperature, state: state)
+            state = stepResult.state
+
+            let nextEventID = try sampleEventID(probabilities: stepResult.softmax, rng: &rng)
+            eventStream.append(nextEventID)
+            generatedCount += 1
+            lastEventID = nextEventID
+
+            if (256 ... 355).contains(nextEventID) {
+                currentStep += (nextEventID - 255)
+            }
+        }
+
+        return codec.decode(eventIDs: eventStream, promptEndTimeSeconds: promptEndTimeSeconds)
+    }
+
+    private func sampleEventID(probabilities: [Float], rng: inout PythonRandom) throws -> Int {
+        guard probabilities.count == PerformanceRNNEventCodec.numClasses else {
+            throw PerformanceRNNImprovGeneratorError.invalidDistribution
+        }
+
+        var sum = 0.0
+        for p in probabilities {
+            if p.isFinite == false { continue }
+            if p > 0 { sum += Double(p) }
+        }
+        guard sum > 0 else {
+            throw PerformanceRNNImprovGeneratorError.invalidDistribution
+        }
+
+        let r = rng.random() * sum
+        var cumulative = 0.0
+        for i in 0 ..< probabilities.count {
+            let p = Double(probabilities[i])
+            if p.isFinite == false || p <= 0 { continue }
+            cumulative += p
+            if r <= cumulative {
+                return i
+            }
+        }
+
+        // Fallback (numeric edge).
+        return probabilities.count - 1
+    }
+}

--- a/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNStepModelProtocol.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNStepModelProtocol.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct PerformanceRNNState: Equatable, Sendable {
+    static let hiddenSize = 512
+
+    var c0: [Float]
+    var h0: [Float]
+    var c1: [Float]
+    var h1: [Float]
+    var c2: [Float]
+    var h2: [Float]
+
+    init(c0: [Float], h0: [Float], c1: [Float], h1: [Float], c2: [Float], h2: [Float]) throws {
+        func validate(_ name: String, _ values: [Float]) throws -> [Float] {
+            guard values.count == Self.hiddenSize else {
+                throw PerformanceRNNStepModelError.invalidStateVector(name: name, expectedCount: Self.hiddenSize, actualCount: values.count)
+            }
+            return values
+        }
+
+        self.c0 = try validate("c0", c0)
+        self.h0 = try validate("h0", h0)
+        self.c1 = try validate("c1", c1)
+        self.h1 = try validate("h1", h1)
+        self.c2 = try validate("c2", c2)
+        self.h2 = try validate("h2", h2)
+    }
+
+    static func zeros() -> PerformanceRNNState {
+        let zeros = Array(repeating: Float.zero, count: hiddenSize)
+        return PerformanceRNNState(uncheckedC0: zeros, uncheckedH0: zeros, uncheckedC1: zeros, uncheckedH1: zeros, uncheckedC2: zeros, uncheckedH2: zeros)
+    }
+
+    private init(
+        uncheckedC0: [Float],
+        uncheckedH0: [Float],
+        uncheckedC1: [Float],
+        uncheckedH1: [Float],
+        uncheckedC2: [Float],
+        uncheckedH2: [Float]
+    ) {
+        c0 = uncheckedC0
+        h0 = uncheckedH0
+        c1 = uncheckedC1
+        h1 = uncheckedH1
+        c2 = uncheckedC2
+        h2 = uncheckedH2
+    }
+}
+
+struct PerformanceRNNStepResult: Equatable, Sendable {
+    static let numClasses = PerformanceRNNEventCodec.numClasses
+
+    var softmax: [Float]
+    var state: PerformanceRNNState
+
+    init(softmax: [Float], state: PerformanceRNNState) throws {
+        guard softmax.count == Self.numClasses else {
+            throw PerformanceRNNStepModelError.invalidSoftmax(expectedCount: Self.numClasses, actualCount: softmax.count)
+        }
+        self.softmax = softmax
+        self.state = state
+    }
+}
+
+enum PerformanceRNNStepModelError: Error, LocalizedError, Equatable, Sendable {
+    case invalidEventID(expectedRange: ClosedRange<Int>, actual: Int)
+    case invalidSoftmax(expectedCount: Int, actualCount: Int)
+    case invalidStateVector(name: String, expectedCount: Int, actualCount: Int)
+    case coreMLPredictionFailed(message: String)
+    case coreMLMissingOutput(name: String)
+    case coreMLInvalidOutputShape(name: String, expectedCount: Int, actualCount: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidEventID(expectedRange, actual):
+            "Invalid eventID=\(actual), expected in \(expectedRange)."
+        case let .invalidSoftmax(expectedCount, actualCount):
+            "Invalid softmax length=\(actualCount), expected \(expectedCount)."
+        case let .invalidStateVector(name, expectedCount, actualCount):
+            "Invalid state vector '\(name)' length=\(actualCount), expected \(expectedCount)."
+        case let .coreMLPredictionFailed(message):
+            "CoreML prediction failed: \(message)"
+        case let .coreMLMissingOutput(name):
+            "CoreML output '\(name)' is missing."
+        case let .coreMLInvalidOutputShape(name, expectedCount, actualCount):
+            "CoreML output '\(name)' has \(actualCount) values, expected \(expectedCount)."
+        }
+    }
+}
+
+protocol PerformanceRNNStepModeling: Sendable {
+    func step(eventID: Int, temperature: Float, state: PerformanceRNNState) async throws -> PerformanceRNNStepResult
+}

--- a/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovBackendKind.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovBackendKind.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum ImprovBackendKind: String, CaseIterable, Codable, Hashable, Identifiable {
     case networkBonjourHTTPDuet = "network_bonjour_http_duet"
+    case localCoreMLDuet = "local_coreml_duet"
     case localRule = "local_rule"
     case tickRangeReplay = "tick_range_replay"
 

--- a/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovBackendSelection.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovBackendSelection.swift
@@ -6,7 +6,7 @@ struct ImprovBackendSelection {
     }
 
     static var defaultKind: ImprovBackendKind {
-        .networkBonjourHTTPDuet
+        .localCoreMLDuet
     }
 
     private let userDefaults: UserDefaults

--- a/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovSeedResolver.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/ImprovSeedResolver.swift
@@ -1,0 +1,32 @@
+import CryptoKit
+import Foundation
+
+/// Shared seed-resolution logic for improv backends.
+///
+/// Behavior (must stay stable):
+/// - Prefer explicit seed.
+/// - Otherwise derive from sessionID using SHA256 (first 8 bytes, big-endian).
+/// - Otherwise return 0.
+struct ImprovSeedResolver: Sendable {
+    init() {}
+
+    func resolveSeed(explicitSeed: UInt64?, sessionID: String?) -> UInt64 {
+        if let explicitSeed {
+            return explicitSeed
+        }
+        if let sessionID {
+            return deriveSeed(fromSessionID: sessionID)
+        }
+        return 0
+    }
+
+    private func deriveSeed(fromSessionID sessionID: String) -> UInt64 {
+        let digest = SHA256.hash(data: Data(sessionID.utf8))
+        var seed: UInt64 = 0
+        for byte in digest.prefix(8) {
+            seed = (seed << 8) | UInt64(byte)
+        }
+        return seed
+    }
+}
+

--- a/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalCoreMLDuetImprovBackend.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalCoreMLDuetImprovBackend.swift
@@ -1,0 +1,82 @@
+import Foundation
+import ImprovProtocol
+
+enum LocalCoreMLDuetImprovBackendError: Error, LocalizedError, Equatable, Sendable {
+    case timeout
+    case emptyReply
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout:
+            "Local CoreML duet backend timed out."
+        case .emptyReply:
+            "Local CoreML duet backend returned an empty reply."
+        }
+    }
+}
+
+actor LocalCoreMLDuetImprovBackend: ImprovBackendProtocol {
+    nonisolated let kind: ImprovBackendKind = .localCoreMLDuet
+    nonisolated let displayName: String = "本地 CoreML（A.I. Duet / Performance RNN）"
+
+    private let modelLoader: any PerformanceRNNCoreMLModelLoading
+    private let generator: PerformanceRNNImprovGenerator
+    private let scheduleBuilder: ImprovScheduleBuilder
+
+    init(
+        modelLoader: any PerformanceRNNCoreMLModelLoading = PerformanceRNNCoreMLModelLoader(),
+        generator: PerformanceRNNImprovGenerator = PerformanceRNNImprovGenerator(),
+        scheduleBuilder: ImprovScheduleBuilder = ImprovScheduleBuilder()
+    ) {
+        self.modelLoader = modelLoader
+        self.generator = generator
+        self.scheduleBuilder = scheduleBuilder
+    }
+
+    func generatePlaybackPlan(
+        request: ImprovGenerateRequest,
+        timeout: Duration
+    ) async throws -> ImprovBackendPlaybackPlan {
+        let stepModel = try await modelLoader.loadStepModel()
+        let generator = self.generator
+
+        let replyNotes = try await runWithTimeout(timeout) {
+            try await generator.generateReplyNotes(
+                promptNotes: request.notes,
+                params: request.params,
+                sessionID: request.sessionID,
+                stepModel: stepModel
+            )
+        }
+
+        let schedule = scheduleBuilder.buildSchedule(from: replyNotes)
+        guard schedule.isEmpty == false else {
+            throw LocalCoreMLDuetImprovBackendError.emptyReply
+        }
+        return .schedule(schedule, backendLatencyMS: nil)
+    }
+
+    private func runWithTimeout<T: Sendable>(
+        _ timeout: Duration,
+        operation: @Sendable @escaping () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask(priority: .userInitiated) {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw LocalCoreMLDuetImprovBackendError.timeout
+            }
+
+            let result = try await group.next()
+            group.cancelAll()
+
+            guard let value = result else {
+                throw LocalCoreMLDuetImprovBackendError.timeout
+            }
+            return value
+        }
+    }
+}
+

--- a/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalRuleImprovBackend.swift
+++ b/LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalRuleImprovBackend.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import ImprovEngines
 import ImprovProtocol
@@ -23,6 +22,7 @@ actor LocalRuleImprovBackend: ImprovBackendProtocol {
 
     private let generator: RuleImprovGenerator
     private let scheduleBuilder: ImprovScheduleBuilder
+    private let seedResolver: ImprovSeedResolver
 
     init(
         generator: RuleImprovGenerator = RuleImprovGenerator(),
@@ -30,13 +30,14 @@ actor LocalRuleImprovBackend: ImprovBackendProtocol {
     ) {
         self.generator = generator
         self.scheduleBuilder = scheduleBuilder
+        seedResolver = ImprovSeedResolver()
     }
 
     func generatePlaybackPlan(
         request: ImprovGenerateRequest,
         timeout: Duration
     ) async throws -> ImprovBackendPlaybackPlan {
-        let seed = resolveSeed(for: request)
+        let seed = seedResolver.resolveSeed(explicitSeed: request.params.seed, sessionID: request.sessionID)
         let generator = self.generator
 
         let replyNotes = try await runWithTimeout(timeout) {
@@ -54,26 +55,6 @@ actor LocalRuleImprovBackend: ImprovBackendProtocol {
         }
 
         return .schedule(schedule, backendLatencyMS: nil)
-    }
-
-    private nonisolated func resolveSeed(for request: ImprovGenerateRequest) -> UInt64 {
-        if let seed = request.params.seed {
-            return seed
-        }
-        if let sessionID = request.sessionID {
-            return deriveSeed(fromSessionID: sessionID)
-        }
-        return 0
-    }
-
-    private nonisolated func deriveSeed(fromSessionID sessionID: String) -> UInt64 {
-        let digest = SHA256.hash(data: Data(sessionID.utf8))
-        let bytes = Array(digest)
-        var seed: UInt64 = 0
-        for i in 0 ..< min(8, bytes.count) {
-            seed = (seed << 8) | UInt64(bytes[i])
-        }
-        return seed
     }
 
     private func runWithTimeout<T: Sendable>(

--- a/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
@@ -191,23 +191,33 @@ final class ARGuideAIPerformanceViewModel {
         let loader = localCoreMLModelLoader
 
         localCoreMLDuetProbeTask = Task.detached(priority: .utility) { [weak self] in
+            let resolvedAvailability: LocalCoreMLDuetAvailability?
             do {
                 _ = try await loader.loadStepModel()
-                await MainActor.run {
-                    self?.localCoreMLDuetAvailability = .available
-                }
+                resolvedAvailability = .available
+            } catch is CancellationError {
+                resolvedAvailability = nil
             } catch let error as PerformanceRNNCoreMLModelLoaderError {
-                await MainActor.run {
-                    switch error {
-                    case let .modelMissing(expectedNames):
-                        self?.localCoreMLDuetAvailability = .missing(expectedNames: expectedNames)
-                    case let .compileFailed(_, message), let .loadFailed(_, message):
-                        self?.localCoreMLDuetAvailability = .failed(message: message)
-                    }
+                switch error {
+                case let .modelMissing(expectedNames):
+                    resolvedAvailability = .missing(expectedNames: expectedNames)
+                case let .compileFailed(_, message), let .loadFailed(_, message):
+                    resolvedAvailability = .failed(message: message)
                 }
             } catch {
+                resolvedAvailability = .failed(message: "Unknown error.")
+            }
+
+            guard Task.isCancelled == false else {
                 await MainActor.run {
-                    self?.localCoreMLDuetAvailability = .failed(message: "Unknown error.")
+                    self?.localCoreMLDuetProbeTask = nil
+                }
+                return
+            }
+
+            if let resolvedAvailability {
+                await MainActor.run {
+                    self?.localCoreMLDuetAvailability = resolvedAvailability
                 }
             }
 

--- a/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
@@ -88,6 +88,8 @@ final class ARGuideAIPerformanceViewModel {
                 state: duetDiscoveryService.state,
                 notFoundHint: "请先在电脑端启动 Duet Python 服务（默认端口 8766）。"
             )
+        case .localCoreMLDuet:
+            "后端：本地 CoreML（A.I. Duet / Performance RNN）需要放置模型文件（AIDuetPerformanceRNN.mlpackage 或 AIDuetPerformanceRNN.mlmodelc）。缺失时生成会失败；可切换到网络或本地 rule。"
         case .localRule:
             "后端：本地规则生成（无需电脑端服务）"
         case .tickRangeReplay:
@@ -100,7 +102,7 @@ final class ARGuideAIPerformanceViewModel {
         case .networkBonjourHTTPDuet:
             duetDiscoveryService.stop()
             duetDiscoveryService.start()
-        case .localRule, .tickRangeReplay:
+        case .localCoreMLDuet, .localRule, .tickRangeReplay:
             break
         }
     }

--- a/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
@@ -8,6 +8,10 @@ final class ARGuideAIPerformanceViewModel {
     let duetDiscoveryService: BonjourBackendDiscoveryService
     private let backendSelection = ImprovBackendSelection()
     private let aiPlaybackServiceFactory: @MainActor () -> DuetAIPlaybackServiceFactory
+    @ObservationIgnored
+    private let localCoreMLModelLoader = PerformanceRNNCoreMLModelLoader()
+
+    var localCoreMLDuetAvailability: LocalCoreMLDuetAvailability = .idle
 
     var isVirtualPerformerEnabled = false
     var isAIPerformanceActive = false
@@ -83,17 +87,18 @@ final class ARGuideAIPerformanceViewModel {
     var backendStatusText: String? {
         switch backendSelection.selectedKind() {
         case .networkBonjourHTTPDuet:
-            backendDiscoveryStatusText(
+            return backendDiscoveryStatusText(
                 backendName: "A.I. Duet",
                 state: duetDiscoveryService.state,
                 notFoundHint: "请先在电脑端启动 Duet Python 服务（默认端口 8766）。"
             )
         case .localCoreMLDuet:
-            "后端：本地 CoreML（A.I. Duet / Performance RNN）需要放置模型文件（AIDuetPerformanceRNN.mlpackage 或 AIDuetPerformanceRNN.mlmodelc）。缺失时生成会失败；可切换到网络或本地 rule。"
+            startLocalCoreMLDuetProbeIfNeeded()
+            return localCoreMLDuetAvailability.statusText()
         case .localRule:
-            "后端：本地规则生成（无需电脑端服务）"
+            return "后端：本地规则生成（无需电脑端服务）"
         case .tickRangeReplay:
-            "后端：按谱片段回放（无需电脑端服务）"
+            return "后端：按谱片段回放（无需电脑端服务）"
         }
     }
 
@@ -102,7 +107,9 @@ final class ARGuideAIPerformanceViewModel {
         case .networkBonjourHTTPDuet:
             duetDiscoveryService.stop()
             duetDiscoveryService.start()
-        case .localCoreMLDuet, .localRule, .tickRangeReplay:
+        case .localCoreMLDuet:
+            restartLocalCoreMLDuetProbe()
+        case .localRule, .tickRangeReplay:
             break
         }
     }
@@ -148,11 +155,66 @@ final class ARGuideAIPerformanceViewModel {
         ImprovBackendRegistry(
             backends: [
                 DuetNetworkBonjourHTTPImprovBackend(discoveryService: duetDiscoveryService),
-                LocalCoreMLDuetImprovBackend(),
+                LocalCoreMLDuetImprovBackend(modelLoader: localCoreMLModelLoader),
                 LocalRuleImprovBackend(),
                 TickRangeReplayImprovBackend(),
             ]
         )
+    }
+
+    @ObservationIgnored
+    private var localCoreMLDuetProbeTask: Task<Void, Never>?
+
+    private func restartLocalCoreMLDuetProbe() {
+        localCoreMLDuetProbeTask?.cancel()
+        localCoreMLDuetProbeTask = nil
+        localCoreMLDuetAvailability = .idle
+        startLocalCoreMLDuetProbeIfNeeded()
+    }
+
+    private func startLocalCoreMLDuetProbeIfNeeded() {
+        guard localCoreMLDuetProbeTask == nil else { return }
+
+        let expectedNames = [
+            "AIDuetPerformanceRNN.mlmodelc",
+            "AIDuetPerformanceRNN.mlpackage",
+        ]
+
+        let hasCompiledInBundle = Bundle.main.url(forResource: "AIDuetPerformanceRNN", withExtension: "mlmodelc") != nil
+        let hasPackageInBundle = Bundle.main.url(forResource: "AIDuetPerformanceRNN", withExtension: "mlpackage") != nil
+        guard hasCompiledInBundle || hasPackageInBundle else {
+            localCoreMLDuetAvailability = .missing(expectedNames: expectedNames)
+            return
+        }
+
+        localCoreMLDuetAvailability = .probing
+        let loader = localCoreMLModelLoader
+
+        localCoreMLDuetProbeTask = Task.detached(priority: .utility) { [weak self] in
+            do {
+                _ = try await loader.loadStepModel()
+                await MainActor.run {
+                    self?.localCoreMLDuetAvailability = .available
+                }
+            } catch let error as PerformanceRNNCoreMLModelLoaderError {
+                await MainActor.run {
+                    switch error {
+                    case let .modelMissing(expectedNames):
+                        self?.localCoreMLDuetAvailability = .missing(expectedNames: expectedNames)
+                    case let .compileFailed(_, message), let .loadFailed(_, message):
+                        self?.localCoreMLDuetAvailability = .failed(message: message)
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self?.localCoreMLDuetAvailability = .failed(message: "Unknown error.")
+                }
+            }
+
+            await MainActor.run {
+                self?.localCoreMLDuetProbeTask = nil
+            }
+        }
     }
 
     private func backendDiscoveryStatusText(
@@ -179,6 +241,27 @@ final class ARGuideAIPerformanceViewModel {
             return "后端：\(backendName)（发现失败：\(message)）"
         case .denied:
             return "后端：\(backendName)（Local Network 权限被拒）请到系统设置开启后重试。"
+        }
+    }
+}
+
+enum LocalCoreMLDuetAvailability: Sendable, Equatable {
+    case idle
+    case probing
+    case available
+    case missing(expectedNames: [String])
+    case failed(message: String)
+
+    func statusText() -> String {
+        switch self {
+        case .idle, .probing:
+            "后端：本地 CoreML（检测中…首次加载可能需要编译模型）"
+        case .available:
+            "后端：本地 CoreML（可用）"
+        case let .missing(expectedNames):
+            "后端：本地 CoreML（缺少模型文件：\(expectedNames.joined(separator: " / "))）请将模型添加到 App bundle 后重试。"
+        case let .failed(message):
+            "后端：本地 CoreML（加载失败：\(message)）可尝试重新放置模型文件或重启后端。"
         }
     }
 }

--- a/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
+++ b/LonelyPianistAVP/ViewModels/ARGuide/ARGuideAIPerformanceViewModel.swift
@@ -148,6 +148,7 @@ final class ARGuideAIPerformanceViewModel {
         ImprovBackendRegistry(
             backends: [
                 DuetNetworkBonjourHTTPImprovBackend(discoveryService: duetDiscoveryService),
+                LocalCoreMLDuetImprovBackend(),
                 LocalRuleImprovBackend(),
                 TickRangeReplayImprovBackend(),
             ]

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -256,7 +256,7 @@ struct PracticeSettingsView: View {
         case .networkBonjourHTTPDuet:
             return backendStatusText ?? "后端：网络本地连接（A.I. Duet / Magenta）"
         case .localCoreMLDuet:
-            return backendStatusText ?? "后端：本地 CoreML（A.I. Duet / Performance RNN）缺少模型文件。可切换到网络或本地 rule。"
+            return backendStatusText ?? "后端：本地 CoreML（A.I. Duet / Performance RNN）"
         case .localRule:
             return backendStatusText ?? "后端：本地规则生成（无需电脑端服务）"
         case .tickRangeReplay:

--- a/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
+++ b/LonelyPianistAVP/Views/Practice/PracticeSettingsView.swift
@@ -254,11 +254,13 @@ struct PracticeSettingsView: View {
 
         switch selectedKind {
         case .networkBonjourHTTPDuet:
-            return backendStatusText ?? "Backend: duet"
+            return backendStatusText ?? "后端：网络本地连接（A.I. Duet / Magenta）"
+        case .localCoreMLDuet:
+            return backendStatusText ?? "后端：本地 CoreML（A.I. Duet / Performance RNN）缺少模型文件。可切换到网络或本地 rule。"
         case .localRule:
-            return "Backend: local rule"
+            return backendStatusText ?? "后端：本地规则生成（无需电脑端服务）"
         case .tickRangeReplay:
-            return "Backend: tick-range replay"
+            return backendStatusText ?? "后端：按谱片段回放（无需电脑端服务）"
         }
     }
 
@@ -266,8 +268,10 @@ struct PracticeSettingsView: View {
         switch kind {
         case .networkBonjourHTTPDuet:
             "网络本地连接（A.I. Duet / Magenta）"
+        case .localCoreMLDuet:
+            "本地 CoreML（A.I. Duet / Performance RNN）"
         case .localRule:
-            "本地 rule（AVP）"
+            "本地 rule（无需模型/无需电脑端）"
         case .tickRangeReplay:
             "按谱片段回放（tick-range replay）"
         }

--- a/LonelyPianistAVPTests/Practice/CoreMLDuet/FakePerformanceRNNStepModel.swift
+++ b/LonelyPianistAVPTests/Practice/CoreMLDuet/FakePerformanceRNNStepModel.swift
@@ -1,0 +1,16 @@
+@testable import LonelyPianistAVP
+
+struct FakePerformanceRNNStepModel: PerformanceRNNStepModeling {
+    let softmax: [Float]
+    let nextState: PerformanceRNNState
+
+    init(softmax: [Float], nextState: PerformanceRNNState = .zeros()) {
+        self.softmax = softmax
+        self.nextState = nextState
+    }
+
+    func step(eventID _: Int, temperature _: Float, state _: PerformanceRNNState) async throws -> PerformanceRNNStepResult {
+        try PerformanceRNNStepResult(softmax: softmax, state: nextState)
+    }
+}
+

--- a/LonelyPianistAVPTests/Practice/CoreMLDuet/PerformanceRNNImprovGeneratorTests.swift
+++ b/LonelyPianistAVPTests/Practice/CoreMLDuet/PerformanceRNNImprovGeneratorTests.swift
@@ -1,0 +1,112 @@
+import ImprovProtocol
+@testable import LonelyPianistAVP
+import Testing
+
+private actor ScriptedStepModel: PerformanceRNNStepModeling {
+    private var warmupRemainingCalls: Int
+    private var scriptedNextEventIDs: [Int]
+    private var index = 0
+    private var receivedEventIDs: [Int] = []
+
+    init(warmupCallCount: Int, scriptedNextEventIDs: [Int]) {
+        warmupRemainingCalls = warmupCallCount
+        self.scriptedNextEventIDs = scriptedNextEventIDs
+    }
+
+    func step(eventID: Int, temperature _: Float, state: PerformanceRNNState) async throws -> PerformanceRNNStepResult {
+        receivedEventIDs.append(eventID)
+        if warmupRemainingCalls > 0 {
+            warmupRemainingCalls -= 1
+            let softmax = oneHot(nextEventID: 0)
+            return try PerformanceRNNStepResult(softmax: softmax, state: state)
+        }
+
+        guard index < scriptedNextEventIDs.count else {
+            let softmax = oneHot(nextEventID: 0)
+            return try PerformanceRNNStepResult(softmax: softmax, state: state)
+        }
+
+        let next = scriptedNextEventIDs[index]
+        index += 1
+        let softmax = oneHot(nextEventID: next)
+        return try PerformanceRNNStepResult(softmax: softmax, state: state)
+    }
+
+    func allReceivedEventIDs() -> [Int] {
+        receivedEventIDs
+    }
+
+    private func oneHot(nextEventID: Int) -> [Float] {
+        var softmax = Array(repeating: Float(0), count: 388)
+        if (0 ..< softmax.count).contains(nextEventID) {
+            softmax[nextEventID] = 1
+        }
+        return softmax
+    }
+}
+
+@Test
+func performanceRNNImprovGenerator_temperatureFromTopP_matchesPythonMapping() {
+    let generator = PerformanceRNNImprovGenerator()
+
+    #expect(abs(generator.temperatureFromTopP(0.7) - 0.8) < 0.0001)
+    #expect(abs(generator.temperatureFromTopP(1.0) - 1.2) < 0.0001)
+    #expect(abs(generator.temperatureFromTopP(0.95) - 1.1333333) < 0.0002)
+    #expect(abs(generator.temperatureFromTopP(0.0) - 0.8) < 0.0001)
+}
+
+@Test
+func performanceRNNImprovGenerator_generatesNonEmptyReplyWithScriptedModel() async throws {
+    let codec = PerformanceRNNEventCodec()
+    let generator = PerformanceRNNImprovGenerator(codec: codec)
+
+    let promptNotes = [
+        ImprovDialogueNote(note: 60, velocity: 80, time: 0.0, duration: 0.5),
+    ]
+    let promptEventIDs = codec.encode(notes: promptNotes)
+    // warmup: promptEventIDs + 1 (forced VELOCITY event after warmup)
+    let warmupCalls = promptEventIDs.count + 1
+
+    // Reply script:
+    // NOTE_ON 64, TIME_SHIFT 50, NOTE_OFF 64, TIME_SHIFT 100, TIME_SHIFT 50
+    let stepModel = ScriptedStepModel(warmupCallCount: warmupCalls, scriptedNextEventIDs: [64, 305, 192, 355, 305])
+
+    let params = ImprovGenerateParams(topP: 0.95, maxTokens: 128, strategy: "model", seed: 1)
+    let reply = try await generator.generateReplyNotes(promptNotes: promptNotes, params: params, sessionID: "s", stepModel: stepModel)
+
+    #expect(reply.isEmpty == false)
+    #expect(reply.allSatisfy { $0.time >= 0.0 })
+    #expect(reply.allSatisfy { $0.duration > 0.0 })
+
+    // Warmup should be prompt events, followed by a forced VELOCITY event.
+    let received = await stepModel.allReceivedEventIDs()
+    #expect(received.count >= warmupCalls)
+    let expectedVelocityEventID = 355 + PerformanceRNNEventCodec.velocityToBin(80)
+    #expect(received[promptEventIDs.count] == expectedVelocityEventID)
+}
+
+@Test
+func performanceRNNImprovGenerator_throwsGenerationLimitExceededWhenNoTimeShiftProgress() async {
+    let codec = PerformanceRNNEventCodec()
+    let generator = PerformanceRNNImprovGenerator(codec: codec)
+
+    let promptNotes = [
+        ImprovDialogueNote(note: 60, velocity: 80, time: 0.0, duration: 0.5),
+    ]
+    let promptEventIDs = codec.encode(notes: promptNotes)
+    let warmupCalls = promptEventIDs.count + 1
+
+    // Only emits NOTE_ON/NOTE_OFF, never TIME_SHIFT -> generator should hit safety limit.
+    let repeatingEvents = Array(repeating: 60, count: 10_000)
+    let stepModel = ScriptedStepModel(warmupCallCount: warmupCalls, scriptedNextEventIDs: repeatingEvents)
+
+    let params = ImprovGenerateParams(topP: 0.95, maxTokens: 1, strategy: "model", seed: 1)
+    do {
+        _ = try await generator.generateReplyNotes(promptNotes: promptNotes, params: params, sessionID: "s", stepModel: stepModel)
+        Issue.record("Expected generationLimitExceeded but generation finished.")
+    } catch let error as PerformanceRNNImprovGeneratorError {
+        #expect(error == .generationLimitExceeded)
+    } catch {
+        Issue.record("Unexpected error: \(String(describing: error))")
+    }
+}

--- a/LonelyPianistAVPTests/Practice/CoreMLDuet/PerformanceRNNStepModelProtocolTests.swift
+++ b/LonelyPianistAVPTests/Practice/CoreMLDuet/PerformanceRNNStepModelProtocolTests.swift
@@ -1,0 +1,33 @@
+@testable import LonelyPianistAVP
+import Testing
+
+@Test
+func performanceRNNState_zerosHasExpectedShape() {
+    let state = PerformanceRNNState.zeros()
+    #expect(state.c0.count == 512)
+    #expect(state.h0.count == 512)
+    #expect(state.c1.count == 512)
+    #expect(state.h1.count == 512)
+    #expect(state.c2.count == 512)
+    #expect(state.h2.count == 512)
+}
+
+@Test
+func performanceRNNStepResult_enforcesSoftmaxLength() {
+    let state = PerformanceRNNState.zeros()
+    #expect(throws: PerformanceRNNStepModelError.invalidSoftmax(expectedCount: 388, actualCount: 0)) {
+        _ = try PerformanceRNNStepResult(softmax: [], state: state)
+    }
+}
+
+@Test
+func fakePerformanceRNNStepModel_returnsExpectedShapes() async throws {
+    let state = PerformanceRNNState.zeros()
+    let softmax = Array(repeating: Float(0), count: 388)
+    let model = FakePerformanceRNNStepModel(softmax: softmax, nextState: state)
+
+    let result = try await model.step(eventID: 0, temperature: 1.0, state: state)
+    #expect(result.softmax.count == 388)
+    #expect(result.state.c0.count == 512)
+}
+

--- a/LonelyPianistAVPTests/Practice/DuetOutOfOrderResponseTests.swift
+++ b/LonelyPianistAVPTests/Practice/DuetOutOfOrderResponseTests.swift
@@ -110,7 +110,7 @@ private struct FakeSettingsProvider: PracticeSessionSettingsProviderProtocol {
 
 @Test
 @MainActor
-func outOfOrderResponsesAreEnqueuedInSendOrder() async {
+func outOfOrderResponsesAreEnqueuedInSendOrder() async throws {
     var nowUptime: TimeInterval = 0
 
     let selectedKind: ImprovBackendKind = .localRule
@@ -189,7 +189,7 @@ func outOfOrderResponsesAreEnqueuedInSendOrder() async {
         nowUptimeSeconds: nowUptime
     )
 
-    #expect(await backend.waitForCallCount(2, maxYields: 10_000))
+    try #require(await backend.waitForCallCount(2, maxYields: 10_000))
 
     // Resume out of order: second call returns before the first.
     let schedule1 = [
@@ -204,12 +204,12 @@ func outOfOrderResponsesAreEnqueuedInSendOrder() async {
     await backend.resumeCall(at: 1, with: .schedule(schedule2, backendLatencyMS: nil))
     await backend.resumeCall(at: 0, with: .schedule(schedule1, backendLatencyMS: nil))
 
-    for _ in 0 ..< 500 {
+    for _ in 0 ..< 10_000 {
         await Task.yield()
         if enqueuedFirstNoteMIDIs.count >= 2 { break }
     }
 
-    #expect(enqueuedFirstNoteMIDIs.count >= 2)
+    try #require(enqueuedFirstNoteMIDIs.count >= 2)
     #expect(enqueuedFirstNoteMIDIs[0] == 60)
     #expect(enqueuedFirstNoteMIDIs[1] == 64)
 

--- a/LonelyPianistAVPTests/Practice/DuetOutOfOrderResponseTests.swift
+++ b/LonelyPianistAVPTests/Practice/DuetOutOfOrderResponseTests.swift
@@ -189,6 +189,7 @@ func outOfOrderResponsesAreEnqueuedInSendOrder() async throws {
         nowUptimeSeconds: nowUptime
     )
 
+    for _ in 0 ..< 200 { await Task.yield() }
     try #require(await backend.waitForCallCount(2, maxYields: 10_000))
 
     // Resume out of order: second call returns before the first.

--- a/LonelyPianistAVPTests/Practice/ImprovSeedResolverTests.swift
+++ b/LonelyPianistAVPTests/Practice/ImprovSeedResolverTests.swift
@@ -1,0 +1,21 @@
+@testable import LonelyPianistAVP
+import Testing
+
+@Test
+func improvSeedResolver_explicitSeedTakesPrecedence() {
+    let resolver = ImprovSeedResolver()
+    #expect(resolver.resolveSeed(explicitSeed: 42, sessionID: "session-123") == 42)
+}
+
+@Test
+func improvSeedResolver_sessionIDDerivesStableSeed() {
+    let resolver = ImprovSeedResolver()
+    #expect(resolver.resolveSeed(explicitSeed: nil, sessionID: "session-123") == 13387023709829870795)
+}
+
+@Test
+func improvSeedResolver_missingInputsReturnsZero() {
+    let resolver = ImprovSeedResolver()
+    #expect(resolver.resolveSeed(explicitSeed: nil, sessionID: nil) == 0)
+}
+

--- a/LonelyPianistAVPTests/Practice/PerformanceRNNEventDecodingTests.swift
+++ b/LonelyPianistAVPTests/Practice/PerformanceRNNEventDecodingTests.swift
@@ -1,0 +1,39 @@
+import ImprovProtocol
+@testable import LonelyPianistAVP
+import Testing
+
+@Test
+func performanceRNNEventCodec_decodesSingleNoteWithVelocity() {
+    let codec = PerformanceRNNEventCodec()
+    let notes = codec.decode(eventIDs: [375, 60, 305, 188], promptEndTimeSeconds: 0.0)
+
+    #expect(notes.count == 1)
+    #expect(notes[0].note == 60)
+    #expect(notes[0].velocity == 77)
+    #expect(notes[0].time == 0.0)
+    #expect(abs(notes[0].duration - 0.5) < 0.0001)
+}
+
+@Test
+func performanceRNNEventCodec_clipsNotesAcrossPromptEnd() {
+    let codec = PerformanceRNNEventCodec()
+    let notes = codec.decode(eventIDs: [375, 60, 305, 188], promptEndTimeSeconds: 0.25)
+
+    #expect(notes.count == 1)
+    #expect(notes[0].time == 0.0)
+    #expect(abs(notes[0].duration - 0.25) < 0.0001)
+}
+
+@Test
+func performanceRNNEventCodec_decodesChordInStableOrder() {
+    let codec = PerformanceRNNEventCodec()
+    let notes = codec.decode(eventIDs: [375, 60, 64, 67, 330, 188, 192, 195], promptEndTimeSeconds: 0.0)
+
+    #expect(notes.count == 3)
+    #expect(notes[0].note == 60)
+    #expect(notes[1].note == 64)
+    #expect(notes[2].note == 67)
+    #expect(notes.allSatisfy { $0.time >= 0.0 })
+    #expect(notes.allSatisfy { $0.duration > 0.0 })
+}
+

--- a/LonelyPianistAVPTests/Practice/PerformanceRNNEventEncodingTests.swift
+++ b/LonelyPianistAVPTests/Practice/PerformanceRNNEventEncodingTests.swift
@@ -1,0 +1,45 @@
+import ImprovProtocol
+@testable import LonelyPianistAVP
+import Testing
+
+@Test
+func performanceRNNEventCodec_velocityBinMapping() {
+    #expect(PerformanceRNNEventCodec.velocityToBin(1) == 1)
+    #expect(PerformanceRNNEventCodec.velocityToBin(4) == 1)
+    #expect(PerformanceRNNEventCodec.velocityToBin(5) == 2)
+    #expect(PerformanceRNNEventCodec.velocityToBin(80) == 20)
+    #expect(PerformanceRNNEventCodec.velocityToBin(127) == 32)
+
+    #expect(PerformanceRNNEventCodec.binToVelocity(1) == 1)
+    #expect(PerformanceRNNEventCodec.binToVelocity(20) == 77)
+    #expect(PerformanceRNNEventCodec.binToVelocity(32) == 125)
+}
+
+@Test
+func performanceRNNEventCodec_encodesArpeggioAsGoldenEventIDs() {
+    let notes = [
+        ImprovDialogueNote(note: 60, velocity: 80, time: 0.0, duration: 0.5),
+        ImprovDialogueNote(note: 64, velocity: 80, time: 0.5, duration: 0.5),
+        ImprovDialogueNote(note: 67, velocity: 80, time: 1.0, duration: 0.5),
+    ]
+
+    let codec = PerformanceRNNEventCodec()
+    let eventIDs = codec.encode(notes: notes)
+
+    #expect(eventIDs == [375, 60, 305, 188, 64, 305, 192, 67, 305, 195])
+}
+
+@Test
+func performanceRNNEventCodec_encodesChordAsGoldenEventIDs() {
+    let notes = [
+        ImprovDialogueNote(note: 60, velocity: 80, time: 0.0, duration: 0.75),
+        ImprovDialogueNote(note: 64, velocity: 80, time: 0.0, duration: 0.75),
+        ImprovDialogueNote(note: 67, velocity: 80, time: 0.0, duration: 0.75),
+    ]
+
+    let codec = PerformanceRNNEventCodec()
+    let eventIDs = codec.encode(notes: notes)
+
+    #expect(eventIDs == [375, 60, 64, 67, 330, 188, 192, 195])
+}
+

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -100,6 +100,7 @@ flowchart TD
 
 practice 窗口的 settings popover 中可选择后端：
 
+- `本地 CoreML（A.I. Duet / Performance RNN）`：AVP 端使用 CoreML 运行 Performance RNN 单步模型做自回归采样；模型文件（`AIDuetPerformanceRNN.mlpackage` / `AIDuetPerformanceRNN.mlmodelc`）不入库，由开发者本地放置并加入 Xcode target。
 - `网络本地连接（A.I. Duet）`：通过 Bonjour 发现 + HTTP 请求调用本机 Duet Python 服务（电脑端运行）。
 - `本地规则生成（Local rule）`：AVP 端直接调用 SwiftPM `ImprovEngines`（seed 可复现）。
 - `按谱片段回放（tick-range replay）`：不做生成，回放当前谱面片段；它不是自动 fallback，只会在用户选择时使用。
@@ -115,7 +116,12 @@ sequenceDiagram
 
   Settings-->>AVP: selected ImprovBackendKind
   AVP->>Backend: generatePlaybackPlan(request)
-  alt local rule
+  alt local CoreML duet (Performance RNN)
+    Backend->>AVP: load step model from app bundle
+    AVP-->>Backend: step model handle
+    Backend-->>Backend: warmup + sampling loop (seeded)
+    Backend-->>AVP: schedule
+  else local rule
     Backend->>Engines: generate(notes, params, seed)
     Engines-->>Backend: generated notes
     Backend-->>AVP: schedule
@@ -130,4 +136,4 @@ sequenceDiagram
   end
 ```
 
-Python 后端是可选网络后端；本地规则生成已迁移到 SwiftPM（`Packages/ImprovEngines/`），仅用于 AVP 端的本地生成路径。
+Python 后端是可选网络后端；本地规则生成已迁移到 SwiftPM（`Packages/ImprovEngines/`）。当前默认后端为本地 CoreML（若未放置模型文件，UI 会提示缺失并可手动切换到网络/本地 rule）。

--- a/docs/modules/improv-engines.md
+++ b/docs/modules/improv-engines.md
@@ -10,5 +10,45 @@
 AVP 侧通过后端实现接入：
 
 - `LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalRuleImprovBackend.swift`
+- `LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalCoreMLDuetImprovBackend.swift`
 
 注意：后端选择在 practice 的 settings popover 中进行，并且严格只使用用户所选后端（失败只提示，不自动切换）。
+
+## Local CoreML Duet（Performance RNN）
+
+本地 CoreML 后端使用 Performance RNN 的单步模型做自回归采样（seed 可复现），模型文件不入库。
+
+相关代码：
+
+- `LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNCoreMLModelLoader.swift`
+- `LonelyPianistAVP/Services/Practice/AI/CoreMLDuet/PerformanceRNNImprovGenerator.swift`
+- `LonelyPianistAVP/Services/Practice/AI/ImprovBackends/LocalCoreMLDuetImprovBackend.swift`
+
+### 1) 生成 CoreML 模型（.mlpackage）
+
+使用仓库内脚本把 Magenta `.mag` bundle 转成 `AIDuetPerformanceRNN.mlpackage`：
+
+```bash
+python3 python_backend/duet/convert_performance_rnn_to_coreml.py \
+  --out LonelyPianistAVP/Resources/Models/AIDuetPerformanceRNN.mlpackage
+```
+
+备注：
+
+- 脚本依赖 `tensorflow` / `note-seq` / `coremltools` / `numpy` 等 Python 包（按你的 Python 环境自行安装）。
+- 默认输入 bundle 是 `python_backend/duet/models/performance_with_dynamics.mag`（若你有其他 bundle，可用 `--bundle` 指定）。
+
+### 2) 放置并加入 Xcode target
+
+推荐本地放置路径：
+
+- `LonelyPianistAVP/Resources/Models/AIDuetPerformanceRNN.mlpackage`
+
+该目录与模型文件类型已在 `.gitignore` 中忽略（避免误提交）。
+
+然后在 Xcode 中把模型加入 `LonelyPianistAVP` target（确保 Target Membership 勾选 `LonelyPianistAVP`），让它随 app bundle 一起打包。
+
+### 3) 排障
+
+- UI 显示缺少模型：检查文件名是否为 `AIDuetPerformanceRNN.mlpackage` 或 `AIDuetPerformanceRNN.mlmodelc`，以及是否加入了 `LonelyPianistAVP` target。
+- 首次加载较慢：若 bundle 中是 `.mlpackage`，首次运行可能会触发 `MLModel.compileModel` 的编译开销，属于正常现象。


### PR DESCRIPTION
### 背景
- 旧实现默认把 AVP 即兴后端指向网络 A.I. Duet；本机 Python 服务没起时，虚拟演奏家无法直接生成，只能手动切换后端。
- 本地 rule 和后端选择各自散落 seed 解析逻辑；同一 session 的确定性来源不统一，后续维护容易出现不一致。
- 练习设置页只给出泛化文案；模型缺失、首次编译和加载失败无法区分，排障成本高。

### 变更
#### 本地 CoreML 即兴链路
- 新增 `PerformanceRNNEventCodec`、`PerformanceRNNStepModeling`、`CoreMLPerformanceRNNStepModel`、`PerformanceRNNCoreMLModelLoader`、`PerformanceRNNImprovGenerator` 和 `LocalCoreMLDuetImprovBackend`，把 Performance RNN 单步模型接成可调用的本地生成后端。
- 编解码按 Magenta 388 类词表处理 NOTE_ON / NOTE_OFF / TIME_SHIFT / VELOCITY，生成时先做 prompt warmup，再按 seed 采样；同时限制生成长度和事件上限，避免无 TIME_SHIFT 时无限循环。
- 模型加载同时支持 bundle 内 `.mlmodelc` 和 `.mlpackage`；若是 package，会先编译再缓存到 Caches 目录，减少后续启动成本。

#### 后端选择与状态提示
- `ImprovBackendKind` 新增 `localCoreMLDuet`，`ImprovBackendSelection.defaultKind` 改为本地 CoreML，让 AVP 默认走离线模型，而不是强依赖电脑端服务。
- `ARGuideAIPerformanceViewModel` 将本地 CoreML 后端注册进 `ImprovBackendRegistry`，并在选择该后端时异步探测模型可用性、编译结果和失败原因。
- `PracticeSettingsView` 增加对应选项与状态文案，显示“可用 / 缺少模型 / 加载失败”，避免继续使用旧的泛化提示。
- 探测任务用 `Task.detached(priority: .utility)` 跑，并在取消时清空任务句柄，避免切换后端时状态被旧任务回写。

#### seed 规则复用
- 抽出 `ImprovSeedResolver`，让 local rule 和 local CoreML 共用同一套 seed 解析顺序：显式 seed 优先，其次 `sessionID` 的 SHA256 前 8 字节，否则回落到 0。
- 这样两条本地生成链路对同一输入会得到一致的确定性来源，不再各自实现。

#### 构建与文档
- `.gitignore` 忽略 `.mlpackage` / `.mlmodelc` 和本地模型目录，避免误提交大体积模型产物。
- Xcode 工程把产品引用改回 `BUILT_PRODUCTS_DIR`，去掉机器相关的绝对路径。
- `docs/data-flow.md` 和 `docs/modules/improv-engines.md` 补充了本地 CoreML Duet 的放置、加载和排障说明。

### 测试
- 运行 `xcodebuild test -scheme LonelyPianistAVP ...`，期望 `PerformanceRNNEventEncodingTests`、`PerformanceRNNEventDecodingTests`、`PerformanceRNNImprovGeneratorTests`、`PerformanceRNNStepModelProtocolTests`、`ImprovSeedResolverTests`、`DuetOutOfOrderResponseTests` 全部通过。
- 准备 `AIDuetPerformanceRNN.mlpackage` 后进入练习设置页并选择本地 CoreML，期望状态先显示探测中，随后变为可用。
- 移除 App bundle 内的 `AIDuetPerformanceRNN.mlpackage/.mlmodelc` 后启动，期望状态明确提示缺少模型文件。
- 用相同 `sessionID` 和显式 seed 分别走 local rule / local CoreML，期望生成结果保持可复现，且显式 seed 优先于 session 派生 seed。