### PR TITLE
修复曲库和练习进度相关问题

### DIFF
--- a/HappyPianistAVP/Models/Diagnostics/DiagnosticModels.swift
+++ b/HappyPianistAVP/Models/Diagnostics/DiagnosticModels.swift
@@ -50,6 +50,7 @@ enum DiagnosticCode: String, Codable, CaseIterable, Sendable {
     case libraryImportConflictAmbiguous = "LIBRARY_IMPORT_CONFLICT_AMBIGUOUS"
     case practiceHistoryResolution = "PRACTICE_HISTORY_RESOLUTION"
     case practiceScoreMetadataWriteFailed = "PRACTICE_SCORE_METADATA_WRITE_FAILED"
+    case practiceProgressSaveFailed = "PRACTICE_PROGRESS_SAVE_FAILED"
     case diagnosticsStoreWriteFailed = "DIAGNOSTICS_STORE_WRITE_FAILED"
     case diagnosticsRetentionCleanupFailed = "DIAGNOSTICS_RETENTION_CLEANUP_FAILED"
     case diagnosticsExportFailed = "DIAGNOSTICS_EXPORT_FAILED"

--- a/HappyPianistAVP/Models/Library/SongLibraryImportTransactionModels.swift
+++ b/HappyPianistAVP/Models/Library/SongLibraryImportTransactionModels.swift
@@ -201,7 +201,7 @@ enum SongLibraryImportProcessResult: Equatable, Sendable {
 
 enum SongLibraryImportState: Equatable, Sendable {
     case idle
-    case staging(index: Int, count: Int)
+    case staging(count: Int)
     case processing(operationID: UUID, index: Int, count: Int)
     case awaitingConfirmation(SongLibraryPendingImport, index: Int, count: Int)
     case itemFailure(SongLibraryImportItemFailure, index: Int, count: Int)

--- a/HappyPianistAVP/Models/Library/SongPracticeLibrarySnapshot.swift
+++ b/HappyPianistAVP/Models/Library/SongPracticeLibrarySnapshot.swift
@@ -28,7 +28,7 @@ struct SongPracticeLibrarySnapshot: Equatable, Sendable {
 
     let identity: SongPracticeLibrarySelectionIdentity
     let status: Status
-    let latestPracticeDate: Date
+    let latestPracticeDate: Date?
     let totalSourceMeasureCount: Int
     let currentFacts: SongPracticeCurrentFacts?
     let hasHistory: Bool
@@ -37,13 +37,13 @@ struct SongPracticeLibrarySnapshot: Equatable, Sendable {
 enum SongPracticeLibrarySnapshotBuildResult: Equatable, Sendable {
     case neverPracticed
     case current(SongPracticeLibrarySnapshot)
-    case needsRebuild(historyDate: Date)
+    case needsRebuild(historyDate: Date?)
 }
 
 enum SongPracticeLibraryPresentationState: Equatable, Sendable {
     case loading(SongPracticeLibrarySelectionIdentity)
     case neverPracticed(SongPracticeLibrarySelectionIdentity)
     case current(SongPracticeLibrarySnapshot)
-    case needsRebuild(SongPracticeLibrarySelectionIdentity, historyDate: Date)
+    case needsRebuild(SongPracticeLibrarySelectionIdentity, historyDate: Date?)
     case unavailable(SongPracticeLibrarySelectionIdentity)
 }

--- a/HappyPianistAVP/Models/Practice/PracticeLaunchModels.swift
+++ b/HappyPianistAVP/Models/Practice/PracticeLaunchModels.swift
@@ -103,7 +103,7 @@ struct PracticeLaunchFailure: Equatable, Identifiable, Sendable {
             timestamp: occurredAt,
             severity: .error,
             code: code,
-            category: .practicePreparation,
+            category: code == .practiceProgressSaveFailed ? .persistence : .practicePreparation,
             stage: stage,
             summary: title,
             reason: reason,
@@ -111,6 +111,18 @@ struct PracticeLaunchFailure: Equatable, Identifiable, Sendable {
             file: file,
             sourceLocation: sourceLocation,
             persistence: .exportable
+        )
+    }
+
+    static func progressSaveFailed(entryID: UUID) -> PracticeLaunchFailure {
+        PracticeLaunchFailure(
+            entryID: entryID,
+            code: .practiceProgressSaveFailed,
+            title: "无法保存上一首曲目的进度",
+            explanation: "当前练习仍被保留。请检查存储空间后重试。",
+            stage: "practiceProgressHandoff",
+            file: nil,
+            reason: "Previous practice progress could not be saved before the next launch."
         )
     }
 

--- a/HappyPianistAVP/Services/Library/SongLibraryIndexStore.swift
+++ b/HappyPianistAVP/Services/Library/SongLibraryIndexStore.swift
@@ -158,6 +158,15 @@ actor SongLibraryIndexStore: SongLibraryImportIndexStoreProtocol {
         }
 
         let data = try Data(contentsOf: indexFileURL)
+        if data.isEmpty {
+            return .empty
+        }
+        if let text = String(data: data, encoding: .utf8),
+           text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return .empty
+        }
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         do {

--- a/HappyPianistAVP/Services/Library/SongPracticeLibrarySnapshotBuilder.swift
+++ b/HappyPianistAVP/Services/Library/SongPracticeLibrarySnapshotBuilder.swift
@@ -26,9 +26,10 @@ struct SongPracticeLibrarySnapshotBuilder: SongPracticeLibrarySnapshotBuilding {
             history.progresses.filter { $0.identity.songID == entry.id }
         )
         let realHistoricalFacts = progresses.flatMap(\.measureFacts).filter(hasRealAttempt)
-        guard let latestPracticeDate = realHistoricalFacts.compactMap(\.lastAttemptAt).max() else {
+        guard realHistoricalFacts.isEmpty == false else {
             return .neverPracticed
         }
+        let latestPracticeDate = realHistoricalFacts.compactMap(\.lastAttemptAt).max()
 
         let metadata = SongScorePracticeMetadataOrder.preferred(
             in: history.scoreMetadata.filter {
@@ -119,7 +120,7 @@ struct SongPracticeLibrarySnapshotBuilder: SongPracticeLibrarySnapshotBuilding {
     }
 
     private nonisolated func hasRealAttempt(_ fact: MeasurePracticeFacts) -> Bool {
-        fact.lastAttemptAt != nil
+        fact.successfulAttempts > 0 || fact.failedAttempts > 0 || fact.lastAttemptAt != nil
     }
 
     private nonisolated func validResumeSourceMeasureID(

--- a/HappyPianistAVP/Services/Practice/Progress/PracticeProgressCoordinator.swift
+++ b/HappyPianistAVP/Services/Practice/Progress/PracticeProgressCoordinator.swift
@@ -112,6 +112,7 @@ actor PracticeProgressCoordinator {
     func finish(generation: Int) async -> PracticeProgressSaveStatus {
         let status = await flush(generation: generation)
         guard generation == currentGeneration else { return status }
+        if case .failed = status { return status }
         delayedFlushTask?.cancel()
         delayedFlushTask = nil
         currentIdentity = nil

--- a/HappyPianistAVP/ViewModels/ARGuide/ARGuideViewModel.swift
+++ b/HappyPianistAVP/ViewModels/ARGuide/ARGuideViewModel.swift
@@ -36,7 +36,7 @@ final class ARGuideViewModel: PracticeLaunchApplying {
 
     var practiceSessionViewModel: PracticeSessionViewModel
     var latestPreparedPractice: PreparedPractice?
-    var practiceSessionReplacementErrorMessage: String?
+    var practiceProgressSaveErrorMessage: String?
     @ObservationIgnored private var latestPracticeRestorePolicy: PracticeLaunchRestorePolicy?
 
     @ObservationIgnored private var handTrackingConsumerTask: Task<Void, Never>?
@@ -249,24 +249,43 @@ final class ARGuideViewModel: PracticeLaunchApplying {
         preparedPracticeApplicationID = nil
     }
 
-    func clearPreparedPracticeForLaunch() async {
+    @discardableResult
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus {
         preparedPracticeApplicationID = nil
-        latestPreparedPractice = nil
-        latestPracticeRestorePolicy = nil
-        practiceSetupState.clearSongAndSteps()
         invalidatePracticeFeedbackPresentation()
 
+        var finalStatus: PracticeProgressSaveStatus = .idle
         var session = practiceSessionViewModel
         while true {
-            await session.suspendAndFlushProgress()
-            await session.finishProgressSession()
+            let flushStatus = await session.suspendAndFlushProgress()
+            if case .failed = flushStatus {
+                session.resumeAfterSuspension()
+                publishPracticeProgressSaveFailure()
+                return flushStatus
+            }
+            let finishStatus = await session.finishProgressSession()
+            if case .failed = finishStatus {
+                session.resumeAfterSuspension()
+                publishPracticeProgressSaveFailure()
+                return finishStatus
+            }
+            finalStatus = finishStatus == .idle ? flushStatus : finishStatus
             session.clearPreparedSong()
             guard practiceSessionViewModel !== session else { break }
             session = practiceSessionViewModel
         }
+
+        latestPreparedPractice = nil
+        latestPracticeRestorePolicy = nil
+        practiceSetupState.clearSongAndSteps()
         if practiceSessionViewModel.hasShutdown {
-            await replacePracticeSessionViewModel()
+            let replacementResult = await replacePracticeSessionViewModel()
+            if replacementResult == .progressSaveFailed {
+                return .failed(message: "Practice progress could not be saved.")
+            }
         }
+        practiceProgressSaveErrorMessage = nil
+        return finalStatus
     }
 
     @discardableResult
@@ -275,10 +294,10 @@ final class ARGuideViewModel: PracticeLaunchApplying {
             practiceSessionViewModel.sessionProgress != nil
         let saveStatus = await practiceSessionViewModel.flushAndShutdown()
         if case .failed = saveStatus {
-            practiceSessionReplacementErrorMessage = "练习进度尚未保存，设置没有应用。请检查存储空间后重试。"
+            practiceProgressSaveErrorMessage = "练习进度尚未保存，设置没有应用。请检查存储空间后重试。"
             return .progressSaveFailed
         }
-        practiceSessionReplacementErrorMessage = nil
+        practiceProgressSaveErrorMessage = nil
         let next = makePracticeSessionViewModel(practiceSetupState.selectedPianoModeID)
         practiceSessionViewModel = next
         placementViewModel.updatePracticeSession(next)
@@ -318,8 +337,12 @@ final class ARGuideViewModel: PracticeLaunchApplying {
         return .replaced
     }
 
-    func clearPracticeSessionReplacementError() {
-        practiceSessionReplacementErrorMessage = nil
+    func clearPracticeProgressSaveError() {
+        practiceProgressSaveErrorMessage = nil
+    }
+
+    private func publishPracticeProgressSaveFailure() {
+        practiceProgressSaveErrorMessage = "练习进度尚未保存。请检查存储空间后重试。"
     }
 
     var calibration: PianoCalibration? {
@@ -605,14 +628,21 @@ final class ARGuideViewModel: PracticeLaunchApplying {
         practiceSessionViewModel.resumeAfterSuspension()
     }
 
-    func leavePracticeStep() async {
-        await practiceSessionViewModel.flushAndShutdown()
+    @discardableResult
+    func leavePracticeStep() async -> PracticeProgressSaveStatus {
+        let saveStatus = await practiceSessionViewModel.flushAndShutdown()
+        if case .failed = saveStatus {
+            publishPracticeProgressSaveFailure()
+            return saveStatus
+        }
+        practiceProgressSaveErrorMessage = nil
         recordingViewModel.stop()
         takePlaybackViewModel.stop()
         setPracticeAutoplayEnabled(false)
         hideVirtualPiano()
         setPracticeVirtualPerformerEnabled(false)
         resetPracticeLocalizationState()
+        return saveStatus
     }
 
     var recordingElapsedText: String {

--- a/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
+++ b/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
@@ -9,7 +9,7 @@ final class SongLibraryViewModel {
     private let fileStore: SongFileStoreProtocol
     private let audioImportService: AudioImportServiceProtocol
     private let bundledProvider: BundledSongLibraryProviderProtocol
-    private let bootstrapLoader: (any SongLibraryBootstrapLoading)?
+    private let bootstrapLoader: any SongLibraryBootstrapLoading
     private var bundledEntries: [SongLibraryEntry]
     private let audioPlaybackController: SongAudioPlaybackStateController
     private let practiceProgressRepository: any PracticeProgressRepositoryProtocol
@@ -62,7 +62,7 @@ final class SongLibraryViewModel {
         practiceProgressRepository: any PracticeProgressRepositoryProtocol,
         diagnosticsReporter: any DiagnosticsReporting,
         snapshotBuilder: any SongPracticeLibrarySnapshotBuilding = SongPracticeLibrarySnapshotBuilder(),
-        bootstrapLoader: (any SongLibraryBootstrapLoading)? = nil,
+        bootstrapLoader: any SongLibraryBootstrapLoading,
         initialSnapshot: SongLibraryBootstrapSnapshot? = nil,
         snapshotSleeper: any SleeperProtocol = TaskSleeper(),
         snapshotSettleDelay: Duration = .milliseconds(150),
@@ -115,10 +115,6 @@ final class SongLibraryViewModel {
 
     func loadLibraryIfNeeded() async {
         guard hasLoadedLibrary == false, isLibraryLoading == false else { return }
-        guard let bootstrapLoader else {
-            hasLoadedLibrary = true
-            return
-        }
 
         isLibraryLoading = true
         let snapshot = await bootstrapLoader.load()
@@ -133,15 +129,6 @@ final class SongLibraryViewModel {
             bootstrapFailureMessage = failure.message
         }
         isLibraryLoading = false
-    }
-
-    func reload() async {
-        do {
-            index = try await indexStore.load()
-            installBootstrapSelection()
-        } catch {
-            errorMessage = "加载乐曲库失败：\(error.localizedDescription)"
-        }
     }
 
     func refreshSelectedPracticeSnapshot() {

--- a/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
+++ b/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
@@ -29,6 +29,7 @@ final class SongLibraryViewModel {
     @ObservationIgnored private var selectionPersistenceNeedsDrain = false
     @ObservationIgnored private var snapshotLoadTask: Task<Void, Never>?
     @ObservationIgnored private var snapshotGeneration = 0
+    @ObservationIgnored private var importStagingTask: Task<SongLibraryImportBatchStageResult, Never>?
     @ObservationIgnored private var importQueue: [SongLibraryImportBatchItem] = []
     @ObservationIgnored private var importQueueIndex = 0
     @ObservationIgnored private var importQueueGeneration = 0
@@ -265,8 +266,15 @@ final class SongLibraryViewModel {
         guard selectedURLs.isEmpty == false, importState.isActive == false else { return }
         importQueueGeneration += 1
         let generation = importQueueGeneration
-        importState = .staging(index: 0, count: selectedURLs.count)
-        let batch = await importTransactionService.stageImports(from: selectedURLs)
+        importState = .staging(count: selectedURLs.count)
+        let stagingTask = Task {
+            await importTransactionService.stageImports(from: selectedURLs)
+        }
+        importStagingTask = stagingTask
+        let batch = await stagingTask.value
+        if generation == importQueueGeneration {
+            importStagingTask = nil
+        }
         guard generation == importQueueGeneration else {
             for item in batch.items {
                 guard case let .staged(descriptor) = item else { continue }
@@ -351,6 +359,10 @@ final class SongLibraryViewModel {
     func cancelAllImports() async {
         guard importState.isActive else { return }
         importQueueGeneration += 1
+        let stagingTask = importStagingTask
+        stagingTask?.cancel()
+        await stagingTask?.value
+        importStagingTask = nil
         let operationIDs = importQueue.dropFirst(importQueueIndex).compactMap { item -> UUID? in
             guard case let .staged(descriptor) = item else { return nil }
             return descriptor.id

--- a/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
+++ b/HappyPianistAVP/ViewModels/Library/SongLibraryViewModel.swift
@@ -624,6 +624,9 @@ final class SongLibraryViewModel {
             syncListeningState()
             updatePlaybackProgressTask()
         } catch {
+            guard generation == listenIntentGeneration,
+                  entries.first(where: { $0.id == entryID })?.audioFileName == audioFileName
+            else { return }
             errorMessage = "播放失败：\(error.localizedDescription)"
         }
     }

--- a/HappyPianistAVP/ViewModels/PracticeLaunch/PracticeLaunchViewModel.swift
+++ b/HappyPianistAVP/ViewModels/PracticeLaunch/PracticeLaunchViewModel.swift
@@ -142,6 +142,7 @@ final class PracticeLaunchViewModel {
             let resolved = try await resolver.resolve(songID: songID)
             fileReference = resolved.diagnosticFileReference
             let history = await progressRepository.history(for: songID)
+            guard isCurrent(songID: songID, generation: generation) else { return }
             if case .corrupted = history {
                 _ = await diagnosticsReporter.record(
                     DiagnosticEvent(
@@ -157,7 +158,6 @@ final class PracticeLaunchViewModel {
                     )
                 )
             }
-            guard isCurrent(songID: songID, generation: generation) else { return }
             _ = await diagnosticsReporter.record(
                 DiagnosticEvent(
                     severity: .info,

--- a/HappyPianistAVP/ViewModels/PracticeLaunch/PracticeLaunchViewModel.swift
+++ b/HappyPianistAVP/ViewModels/PracticeLaunch/PracticeLaunchViewModel.swift
@@ -8,9 +8,15 @@ protocol PracticeLaunchApplying: AnyObject, Sendable {
         restorePolicy: PracticeLaunchRestorePolicy,
         isCurrent: @escaping @MainActor () -> Bool
     ) async -> PracticeLaunchApplyOutcome?
-    func clearPreparedPracticeForLaunch() async
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus
     func suspendPracticeAndFlushProgress() async
-    func leavePracticeStep() async
+    func leavePracticeStep() async -> PracticeProgressSaveStatus
+}
+
+private struct PracticeLaunchReturnContext {
+    let operationID: UUID
+    let requestedSongID: UUID?
+    let state: PracticeLaunchState?
 }
 
 @MainActor
@@ -27,7 +33,7 @@ final class PracticeLaunchViewModel {
     @ObservationIgnored private var activationTask: Task<Void, Never>?
     @ObservationIgnored private var metadataWriteTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var generation = 0
-    @ObservationIgnored private var returnOperationID: UUID?
+    @ObservationIgnored private var returnContext: PracticeLaunchReturnContext?
 
     private(set) var state: PracticeLaunchState?
     private(set) var requestedSongID: UUID?
@@ -101,28 +107,63 @@ final class PracticeLaunchViewModel {
     }
 
     func beginReturn() -> UUID {
-        if let returnOperationID { return returnOperationID }
+        if let returnContext { return returnContext.operationID }
         activationTask?.cancel()
         activationTask = nil
         generation += 1
+        let operationID = UUID()
+        returnContext = PracticeLaunchReturnContext(
+            operationID: operationID,
+            requestedSongID: requestedSongID,
+            state: state
+        )
         requestedSongID = nil
         activationIdentity = nil
-        let operationID = UUID()
-        returnOperationID = operationID
         return operationID
     }
 
-    func finishReturn(operationID: UUID) async {
-        guard returnOperationID == operationID else { return }
-        returnOperationID = nil
-        await applicator.clearPreparedPracticeForLaunch()
+    func abortReturn(operationID: UUID) {
+        guard let context = returnContext, context.operationID == operationID else { return }
+        returnContext = nil
+        generation += 1
+        requestedSongID = context.requestedSongID
+        guard let songID = context.requestedSongID else {
+            state = nil
+            activationIdentity = nil
+            return
+        }
+        switch context.state {
+        case .requested, .loading, nil:
+            state = .requested(songID: songID)
+        case .failure, .ready:
+            state = context.state
+        }
+        activationIdentity = PracticeLaunchActivationIdentity(
+            songID: songID,
+            revision: generation
+        )
+    }
+
+    @discardableResult
+    func finishReturn(operationID: UUID) async -> PracticeProgressSaveStatus {
+        guard returnContext?.operationID == operationID else { return .idle }
+        let status = await applicator.clearPreparedPracticeForLaunch()
+        guard returnContext?.operationID == operationID else {
+            return .failed(message: "Return operation was superseded.")
+        }
+        if case .failed = status {
+            abortReturn(operationID: operationID)
+            return status
+        }
+        returnContext = nil
+        return status
     }
 
     private func registerRequest(songID: UUID) {
         activationTask?.cancel()
         activationTask = nil
         generation += 1
-        returnOperationID = nil
+        returnContext = nil
         requestedSongID = songID
         state = .requested(songID: songID)
         activationIdentity = PracticeLaunchActivationIdentity(
@@ -134,8 +175,14 @@ final class PracticeLaunchViewModel {
     private func performActivation(songID: UUID, generation: Int) async {
         guard isCurrent(songID: songID, generation: generation) else { return }
         state = .loading(songID: songID)
-        await applicator.clearPreparedPracticeForLaunch()
+        let clearStatus = await applicator.clearPreparedPracticeForLaunch()
         guard isCurrent(songID: songID, generation: generation) else { return }
+        if case .failed = clearStatus {
+            let failure = PracticeLaunchFailure.progressSaveFailed(entryID: songID)
+            state = .failure(failure)
+            _ = await diagnosticsReporter.record(failure.diagnosticEvent)
+            return
+        }
 
         var fileReference: DiagnosticFileReference?
         do {

--- a/HappyPianistAVP/ViewModels/PracticeSession/PracticeSessionViewModelCommands.swift
+++ b/HappyPianistAVP/ViewModels/PracticeSession/PracticeSessionViewModelCommands.swift
@@ -292,11 +292,14 @@ extension PracticeSessionViewModel {
         return finalStatus
     }
 
-    func finishProgressSession() async {
-        guard let progressCoordinator, let generation = self.progressGeneration else { return }
-        _ = await progressCoordinator.finish(generation: generation)
-        guard self.progressGeneration == generation else { return }
+    @discardableResult
+    func finishProgressSession() async -> PracticeProgressSaveStatus {
+        guard let progressCoordinator, let generation = self.progressGeneration else { return .idle }
+        let status = await progressCoordinator.finish(generation: generation)
+        guard self.progressGeneration == generation else { return status }
+        if case .failed = status { return status }
         self.progressGeneration = nil
+        return status
     }
 
     func recordAttemptOutcome(_ outcome: StepAttemptMatchResult, at timestamp: Date = .now) {

--- a/HappyPianistAVP/Views/Library/LibraryPracticeProgressOrnamentView.swift
+++ b/HappyPianistAVP/Views/Library/LibraryPracticeProgressOrnamentView.swift
@@ -26,7 +26,7 @@ struct LibraryPracticeProgressOrnamentView: View {
                 LibraryPracticeMessageView(
                     systemImage: "arrow.trianglehead.2.clockwise.rotate.90",
                     title: "当前版本尚未建立进度",
-                    message: "保留了历史记录（最近练习：\(historyDate.formatted(date: .abbreviated, time: .shortened))）。开始一次练习后会重建当前结构。"
+                    message: rebuildMessage(historyDate: historyDate)
                 )
             case .unavailable:
                 LibraryPracticeMessageView(
@@ -40,6 +40,13 @@ struct LibraryPracticeProgressOrnamentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("当前曲目练习概览")
+    }
+
+    private func rebuildMessage(historyDate: Date?) -> String {
+        guard let historyDate else {
+            return "保留了历史练习事实。开始一次练习后会重建当前结构。"
+        }
+        return "保留了历史记录（最近练习：\(historyDate.formatted(date: .abbreviated, time: .shortened))）。开始一次练习后会重建当前结构。"
     }
 }
 
@@ -72,8 +79,10 @@ private struct LibraryPracticeCurrentSnapshotView: View {
                 .font(.headline)
                 .bold()
 
-            LabeledContent("最近练习") {
-                Text(snapshot.latestPracticeDate, format: .dateTime.month().day().hour().minute())
+            if let latestPracticeDate = snapshot.latestPracticeDate {
+                LabeledContent("最近练习") {
+                    Text(latestPracticeDate, format: .dateTime.month().day().hour().minute())
+                }
             }
 
             if snapshot.totalSourceMeasureCount > 0 {

--- a/HappyPianistAVP/Views/Library/SongLibraryView.swift
+++ b/HappyPianistAVP/Views/Library/SongLibraryView.swift
@@ -431,8 +431,8 @@ private struct LibraryImportStatusView: View {
 
   private var statusText: String {
     switch state {
-    case let .staging(index, count):
-      "正在暂存曲谱 \(min(index + 1, count))/\(count)…"
+    case let .staging(count):
+      "正在暂存 \(count) 项曲谱…"
     case let .processing(_, index, count):
       "正在导入第 \(index)/\(count) 项…"
     case let .awaitingConfirmation(pending, index, count):

--- a/HappyPianistAVP/Views/Practice/PracticeStepView.swift
+++ b/HappyPianistAVP/Views/Practice/PracticeStepView.swift
@@ -222,15 +222,15 @@ struct PracticeStepView: View {
         } message: {
             Text(session.autoplayErrorMessage ?? "")
         }
-        .onChange(of: viewModel.practiceSessionReplacementErrorMessage) {
-            isSessionReplacementErrorAlertPresented = viewModel.practiceSessionReplacementErrorMessage != nil
+        .onChange(of: viewModel.practiceProgressSaveErrorMessage) {
+            isSessionReplacementErrorAlertPresented = viewModel.practiceProgressSaveErrorMessage != nil
         }
-        .alert("无法应用设置", isPresented: $isSessionReplacementErrorAlertPresented) {
+        .alert("练习进度尚未保存", isPresented: $isSessionReplacementErrorAlertPresented) {
             Button("知道了") {
-                viewModel.clearPracticeSessionReplacementError()
+                viewModel.clearPracticeProgressSaveError()
             }
         } message: {
-            Text(viewModel.practiceSessionReplacementErrorMessage ?? "")
+            Text(viewModel.practiceProgressSaveErrorMessage ?? "")
         }
         .onDisappear {
             viewModel.practiceFeedbackViewModel.cancel()

--- a/HappyPianistAVP/Views/Practice/PracticeWindowRootView.swift
+++ b/HappyPianistAVP/Views/Practice/PracticeWindowRootView.swift
@@ -69,16 +69,17 @@ struct PracticeWindowRootView: View {
             beginReturn: launchViewModel.beginReturn,
             leave: {
                 await pendingLifecycle?.value
-                await arGuideViewModel.leavePracticeStep()
+                return await arGuideViewModel.leavePracticeStep()
             },
             closeImmersive: {
                 await closeImmersivePresentationIfNeeded()
             },
             recoverImmersive: {},
+            abortReturn: launchViewModel.abortReturn,
             finishReturn: launchViewModel.finishReturn,
             navigate: {
-            windowState.beginTransition(from: .practice, to: .library)
-            openWindow(id: WindowID.library)
+                windowState.beginTransition(from: .practice, to: .library)
+                openWindow(id: WindowID.library)
             }
         )
     }
@@ -160,19 +161,30 @@ final class PracticeWindowReturnCoordinator {
 
     func begin(
         beginReturn: @escaping @MainActor () -> UUID,
-        leave: @escaping @MainActor () async -> Void,
+        leave: @escaping @MainActor () async -> PracticeProgressSaveStatus,
         closeImmersive: @escaping @MainActor () async -> Void,
         recoverImmersive: @escaping @MainActor () async -> Void,
-        finishReturn: @escaping @MainActor (UUID) async -> Void,
+        abortReturn: @escaping @MainActor (UUID) -> Void,
+        finishReturn: @escaping @MainActor (UUID) async -> PracticeProgressSaveStatus,
         navigate: @escaping @MainActor () -> Void
     ) {
         guard operationTask == nil else { return }
         let operationID = beginReturn()
-        operationTask = Task { @MainActor in
-            await leave()
+        operationTask = Task { @MainActor [weak self] in
+            let leaveStatus = await leave()
+            if case .failed = leaveStatus {
+                abortReturn(operationID)
+                self?.operationTask = nil
+                return
+            }
             await closeImmersive()
             await recoverImmersive()
-            await finishReturn(operationID)
+            let finishStatus = await finishReturn(operationID)
+            if case .failed = finishStatus {
+                abortReturn(operationID)
+                self?.operationTask = nil
+                return
+            }
             navigate()
         }
     }

--- a/HappyPianistAVPTests/Library/SongLibraryFileIOIsolationTests.swift
+++ b/HappyPianistAVPTests/Library/SongLibraryFileIOIsolationTests.swift
@@ -25,6 +25,25 @@ func staleAudioURLResolutionCannotStartPlaybackAfterSelectionChanges() async thr
 
 @Test
 @MainActor
+func staleAudioURLFailureDoesNotPublishPlaybackErrorAfterSelectionChanges() async throws {
+    let first = makeListeningEntry(name: "first")
+    let second = makeListeningEntry(name: "second")
+    let fileStore = DelayedFailingListeningFileStore()
+    let viewModel = SongLibraryViewModelTestHarness.make(
+        index: SongLibraryIndex(entries: [first, second], lastSelectedEntryID: first.id),
+        fileStore: fileStore
+    )
+
+    let listenTask = Task { await viewModel.didTapListen(entryID: first.id) }
+    try await waitForFailureRequest(in: fileStore)
+    viewModel.selectEntry(second.id)
+    await listenTask.value
+
+    #expect(viewModel.errorMessage == nil)
+}
+
+@Test
+@MainActor
 func outOfOrderSameEntryAudioResolutionsHonorOnlyLatestIntent() async throws {
     let entry = makeListeningEntry(name: "same")
     let fileStore = DelayedListeningFileStore()
@@ -73,6 +92,28 @@ private actor DelayedListeningFileStore: SongFileStoreProtocol {
         let request = requests
         try await Task.sleep(for: request == 1 ? .milliseconds(50) : .milliseconds(5))
         return URL(fileURLWithPath: "/tmp/audio.mp3")
+    }
+    func deleteScoreFile(named _: String) async throws {}
+    func deleteAudioFile(named _: String) async throws {}
+}
+
+private func waitForFailureRequest(in store: DelayedFailingListeningFileStore) async throws {
+    for _ in 0..<100 {
+        if await store.requestCount == 1 { return }
+        try await Task.sleep(for: .milliseconds(5))
+    }
+    Issue.record("Timed out waiting for failing audio URL request")
+}
+
+private actor DelayedFailingListeningFileStore: SongFileStoreProtocol {
+    private var requests = 0
+    var requestCount: Int { requests }
+
+    func scoreFileURL(fileName _: String) async throws -> URL { throw CocoaError(.fileNoSuchFile) }
+    func audioFileURL(fileName _: String) async throws -> URL {
+        requests += 1
+        try await Task.sleep(for: .milliseconds(50))
+        throw CocoaError(.fileReadUnknown)
     }
     func deleteScoreFile(named _: String) async throws {}
     func deleteAudioFile(named _: String) async throws {}

--- a/HappyPianistAVPTests/Library/SongLibraryImportTransactionTests.swift
+++ b/HappyPianistAVPTests/Library/SongLibraryImportTransactionTests.swift
@@ -855,6 +855,7 @@ func cancellingDuringStagingDiscardsReturnedOperationsByGeneration() async {
     await importTask.value
 
     #expect(viewModel.importState == .idle)
+    #expect(await service.stageCancellationObserved)
     #expect(await service.cancelledOperationIDs == [operationID])
     #expect(await service.processedOperationIDs.isEmpty)
 }
@@ -1220,6 +1221,7 @@ private actor QueueImportTransactionService: SongLibraryImportTransactionServici
     private(set) var cancelledOperationIDs: [UUID] = []
     private(set) var processedOperationIDs: [UUID] = []
     private(set) var confirmedOperationIDs: [UUID] = []
+    private(set) var stageCancellationObserved = false
 
     init(
         items: [SongLibraryImportBatchItem],
@@ -1237,7 +1239,11 @@ private actor QueueImportTransactionService: SongLibraryImportTransactionServici
 
     func stageImports(from _: [URL]) async -> SongLibraryImportBatchStageResult {
         if stageDelay != .zero {
-            try? await Task.sleep(for: stageDelay)
+            do {
+                try await Task.sleep(for: stageDelay)
+            } catch is CancellationError {
+                stageCancellationObserved = true
+            } catch {}
         }
         return SongLibraryImportBatchStageResult(items: items, blocked: nil)
     }

--- a/HappyPianistAVPTests/Library/SongLibraryIndexStoreTests.swift
+++ b/HappyPianistAVPTests/Library/SongLibraryIndexStoreTests.swift
@@ -2,22 +2,38 @@ import Foundation
 @testable import HappyPianistAVP
 import Testing
 
-@Test
-func songLibraryIndexStoreReturnsEmptyOnlyForMissingFile() async throws {
+@Test(arguments: [Data(), Data(" \n\t".utf8)])
+func songLibraryIndexStoreTreatsBlankFilesAsEmpty(data: Data) async throws {
     let fixture = try SongLibraryIndexStoreFixture()
     defer { fixture.remove() }
 
     #expect(try await fixture.store.load() == .empty)
-
     try FileManager.default.createDirectory(
         at: fixture.indexFileURL.deletingLastPathComponent(),
         withIntermediateDirectories: true
     )
-    let indexFileURL = fixture.indexFileURL
-    try Data(" \n\t".utf8).write(to: indexFileURL)
-    await #expect(throws: SongLibraryIndexStoreError.corrupted) {
-        _ = try await fixture.store.load()
-    }
+    try data.write(to: fixture.indexFileURL)
+
+    #expect(try await fixture.store.load() == .empty)
+}
+
+@Test
+func firstMutationReplacesBlankIndexWithValidJSON() async throws {
+    let fixture = try SongLibraryIndexStoreFixture()
+    defer { fixture.remove() }
+    try FileManager.default.createDirectory(
+        at: fixture.indexFileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data(" \n\t".utf8).write(to: fixture.indexFileURL)
+    let entry = makeEntry(name: "first")
+
+    let index = try await fixture.store.appendUserEntry(entry)
+    let persisted = try await fixture.store.load()
+
+    #expect(index.entries == [entry])
+    #expect(persisted == index)
+    #expect(try JSONSerialization.jsonObject(with: Data(contentsOf: fixture.indexFileURL)) is [String: Any])
 }
 
 @Test

--- a/HappyPianistAVPTests/Library/SongLibrarySnapshotLoadingTests.swift
+++ b/HappyPianistAVPTests/Library/SongLibrarySnapshotLoadingTests.swift
@@ -110,24 +110,22 @@ func libraryRefreshCoalescesSameSelectionAndReadsHistoryOnce() async throws {
 
 @Test
 @MainActor
-func libraryReloadBindsSnapshotGenerationToChangedEntryToken() async throws {
+func committedReplacementBindsSnapshotGenerationToChangedEntryToken() async throws {
     let songID = UUID()
     let first = makeLoadingEntry(id: songID, name: "Versioned", token: UUID())
     let second = makeLoadingEntry(id: songID, name: "Versioned", token: UUID())
-    let indexStore = MutableSnapshotIndexStore(
-        index: SongLibraryIndex(entries: [first], lastSelectedEntryID: songID)
-    )
+    let updatedIndex = SongLibraryIndex(entries: [second], lastSelectedEntryID: songID)
+    let importService = CommittedSnapshotImportService(index: updatedIndex, entry: second)
     let repository = FixedHistoryRepository(histories: [
         songID: currentHistory(for: second)
     ])
     let viewModel = SongLibraryViewModelTestHarness.make(
         index: SongLibraryIndex(entries: [first], lastSelectedEntryID: songID),
-        indexStore: indexStore,
+        importTransactionService: importService,
         practiceProgressRepository: repository
     )
-    await indexStore.replaceEntries([second])
 
-    await viewModel.reload()
+    await viewModel.importMusicXML(from: [URL(fileURLWithPath: "/tmp/Versioned.musicxml")])
     try await waitForSnapshotState(viewModel) { state in
         guard case let .current(snapshot) = state else { return false }
         return snapshot.identity == selectionIdentity(second)
@@ -425,45 +423,34 @@ private actor UpdatingHistoryRepository: PracticeProgressRepositoryProtocol {
     func remove(songID _: UUID) {}
 }
 
-private actor MutableSnapshotIndexStore: SongLibraryIndexStoreProtocol {
-    private var index: SongLibraryIndex
+private actor CommittedSnapshotImportService: SongLibraryImportTransactionServicing {
+    private let descriptor = SongLibraryStagedImport(id: UUID(), fileName: "Versioned.musicxml")
+    private let index: SongLibraryIndex
+    private let entry: SongLibraryEntry
 
-    init(index: SongLibraryIndex) { self.index = index }
-    func replaceEntries(_ entries: [SongLibraryEntry]) { index.entries = entries }
-    func load() -> SongLibraryIndex { index }
-    func setLastSelectedEntryID(_ entryID: UUID?) -> SongLibraryIndex {
-        index.lastSelectedEntryID = entryID
-        return index
+    init(index: SongLibraryIndex, entry: SongLibraryEntry) {
+        self.index = index
+        self.entry = entry
     }
-    func appendUserEntry(_ entry: SongLibraryEntry) -> SongLibraryIndex {
-        index.entries.append(entry)
-        return index
+
+    func recoverPendingTransactions() -> SongLibraryTransactionRecoveryResult { .recovered }
+
+    func stageImports(from _: [URL]) -> SongLibraryImportBatchStageResult {
+        SongLibraryImportBatchStageResult(items: [.staged(descriptor)], blocked: nil)
     }
-    func removeUserEntry(
-        id: UUID,
-        fallbackLastSelectedEntryID: UUID?
-    ) -> SongLibraryEntryMutationResult {
-        guard let entryIndex = index.entries.firstIndex(where: { $0.id == id }) else {
-            return .notFound(index: index)
+
+    func process(operationID: UUID) -> SongLibraryImportProcessResult {
+        guard operationID == descriptor.id else {
+            return .blocked(SongLibraryBlockedImport(operationID: operationID, message: "unexpected operation"))
         }
-        let entry = index.entries.remove(at: entryIndex)
-        index.lastSelectedEntryID = fallbackLastSelectedEntryID
-        return .applied(index: index, entry: entry)
+        return .committed(index: index, entry: entry)
     }
-    func updateAudioFileName(
-        entryID: UUID,
-        expectedCurrentFileName: String?,
-        newFileName: String?
-    ) -> SongLibraryEntryMutationResult {
-        guard let entryIndex = index.entries.firstIndex(where: { $0.id == entryID }) else {
-            return .notFound(index: index)
-        }
-        guard index.entries[entryIndex].audioFileName == expectedCurrentFileName else {
-            return .conflict(index: index, entry: index.entries[entryIndex])
-        }
-        index.entries[entryIndex].audioFileName = newFileName
-        return .applied(index: index, entry: index.entries[entryIndex])
+
+    func confirm(operationID: UUID) -> SongLibraryImportProcessResult {
+        .blocked(SongLibraryBlockedImport(operationID: operationID, message: "unexpected confirmation"))
     }
+
+    func cancel(operationID _: UUID) -> Bool { true }
 }
 
 private actor SnapshotScoreAccessSpy: SongFileStoreProtocol {

--- a/HappyPianistAVPTests/Library/SongPracticeLibrarySnapshotBuilderTests.swift
+++ b/HappyPianistAVPTests/Library/SongPracticeLibrarySnapshotBuilderTests.swift
@@ -21,7 +21,7 @@ func snapshotBuilderLeavesMainActorIsolation() async {
 }
 
 @Test
-func snapshotNeverPracticedIgnoresUpdatedAtWithoutAttempts() async {
+func snapshotRecognizesCountOnlyAttemptsWithoutInventingPracticeDate() async {
     let entry = makeSnapshotEntry()
     let progress = SongPracticeProgress(
         identity: PracticeSongIdentity(songID: entry.id, scoreRevision: "r1"),
@@ -34,11 +34,47 @@ func snapshotNeverPracticedIgnoresUpdatedAtWithoutAttempts() async {
         )],
         updatedAt: Date(timeIntervalSince1970: 500)
     )
+    let metadata = makeSnapshotMetadata(
+        songID: entry.id,
+        token: entry.scoreFileVersionID,
+        revision: "r1"
+    )
+
+    guard case let .current(snapshot) = await snapshotBuilder.build(
+        entry: entry,
+        history: PracticeSongHistory(
+            songID: entry.id,
+            progresses: [progress],
+            scoreMetadata: [metadata]
+        )
+    ) else {
+        Issue.record("Expected current snapshot")
+        return
+    }
+    #expect(snapshot.status == .practicedCurrentVersion)
+    #expect(snapshot.latestPracticeDate == nil)
+    #expect(snapshot.currentFacts?.learningSourceMeasureCount == 1)
+}
+
+@Test
+func snapshotNeedsRebuildForCountOnlyHistoryWithoutUsingUpdatedAtAsPracticeDate() async {
+    let entry = makeSnapshotEntry()
+    let progress = SongPracticeProgress(
+        identity: PracticeSongIdentity(songID: entry.id, scoreRevision: "old"),
+        measureFacts: [MeasurePracticeFacts(
+            sourceMeasureID: snapshotSource(0),
+            handMode: .both,
+            state: .learning,
+            failedAttempts: 1,
+            lastAttemptAt: nil
+        )],
+        updatedAt: Date(timeIntervalSince1970: 500)
+    )
 
     #expect(await snapshotBuilder.build(
         entry: entry,
         history: PracticeSongHistory(songID: entry.id, progresses: [progress], scoreMetadata: [])
-    ) == .neverPracticed)
+    ) == .needsRebuild(historyDate: nil))
 }
 
 @Test

--- a/HappyPianistAVPTests/Practice/PracticeLaunchLifecycleTests.swift
+++ b/HappyPianistAVPTests/Practice/PracticeLaunchLifecycleTests.swift
@@ -15,12 +15,17 @@ func duplicatePracticeDisappearAndReturnIntentsRunOneOrderedTeardown() async {
                 calls.append("begin")
                 return operationID
             },
-            leave: { calls.append("leave") },
+            leave: {
+                calls.append("leave")
+                return .saved
+            },
             closeImmersive: { calls.append("close") },
             recoverImmersive: { calls.append("recover") },
+            abortReturn: { _ in calls.append("abort") },
             finishReturn: { receivedID in
                 #expect(receivedID == operationID)
                 calls.append("finish")
+                return .saved
             },
             navigate: { calls.append("navigate") }
         )
@@ -28,6 +33,49 @@ func duplicatePracticeDisappearAndReturnIntentsRunOneOrderedTeardown() async {
     await coordinator.waitForCompletion()
 
     #expect(calls == ["begin", "leave", "close", "recover", "finish", "navigate"])
+}
+
+@MainActor
+@Test
+func failedProgressSaveAbortsReturnWithoutClosingOrNavigatingAndAllowsRetry() async {
+    let coordinator = PracticeWindowReturnCoordinator()
+    var calls: [String] = []
+    var shouldFail = true
+
+    func begin() {
+        coordinator.begin(
+            beginReturn: {
+                calls.append("begin")
+                return UUID()
+            },
+            leave: {
+                calls.append("leave")
+                if shouldFail { return .failed(message: "disk full") }
+                return .saved
+            },
+            closeImmersive: { calls.append("close") },
+            recoverImmersive: { calls.append("recover") },
+            abortReturn: { _ in calls.append("abort") },
+            finishReturn: { _ in
+                calls.append("finish")
+                return .saved
+            },
+            navigate: { calls.append("navigate") }
+        )
+    }
+
+    begin()
+    await coordinator.waitForCompletion()
+    #expect(calls == ["begin", "leave", "abort"])
+    #expect(coordinator.isReturning == false)
+
+    shouldFail = false
+    begin()
+    await coordinator.waitForCompletion()
+    #expect(calls == [
+        "begin", "leave", "abort",
+        "begin", "leave", "close", "recover", "finish", "navigate",
+    ])
 }
 
 @MainActor

--- a/HappyPianistAVPTests/Practice/PracticeLaunchViewModelTests.swift
+++ b/HappyPianistAVPTests/Practice/PracticeLaunchViewModelTests.swift
@@ -95,6 +95,27 @@ func corruptedPracticeHistoryWarnsAndLaunchesWithUnavailablePolicy() async {
 
 @MainActor
 @Test
+func staleCorruptedHistoryDoesNotRecordWarningAfterRequestChanges() async {
+    let fixture = makePracticeLaunchFixture(
+        historyResultOverride: .corrupted(description: "invalid progress document"),
+        historyDelay: .milliseconds(50)
+    )
+    fixture.owner.request(songID: fixture.songA)
+    let activation = Task { @MainActor in
+        await fixture.owner.activateCurrentRequest()
+    }
+    await fixture.metadataRepository.waitUntilHistoryRequested()
+
+    fixture.owner.request(songID: fixture.songB)
+    await activation.value
+
+    let warnings = await fixture.reporter.events.filter { $0.code == .practiceHistoryLoadFailed }
+    #expect(warnings.isEmpty)
+    #expect(fixture.owner.state == .requested(songID: fixture.songB))
+}
+
+@MainActor
+@Test
 func practiceLaunchLatestAtoBtoARequestWins() async throws {
     let songA = UUID()
     let songB = UUID()
@@ -631,7 +652,8 @@ private func makePracticeLaunchFixture(
     includeMeasureSpans: Bool = true,
     applyOutcome: PracticeLaunchApplyOutcome = .applied,
     progresses: [SongPracticeProgress] = [],
-    historyResultOverride: PracticeSongHistoryLoadResult? = nil
+    historyResultOverride: PracticeSongHistoryLoadResult? = nil,
+    historyDelay: Duration = .zero
 ) -> PracticeLaunchFixture {
     let resolver = PracticeLaunchResolver(songIDs: [songA, songB])
     let preparation = PracticeLaunchPreparationService(
@@ -643,7 +665,8 @@ private func makePracticeLaunchFixture(
     let reporter = InMemoryDiagnosticsReporter()
     let metadataRepository = RecordingPracticeLaunchProgressRepository(
         progresses: progresses,
-        historyResultOverride: historyResultOverride
+        historyResultOverride: historyResultOverride,
+        historyDelay: historyDelay
     )
     return PracticeLaunchFixture(
         owner: PracticeLaunchViewModel(
@@ -678,20 +701,28 @@ private actor RecordingPracticeLaunchProgressRepository: PracticeProgressReposit
     private var progresses: [SongPracticeProgress]
     let metadataError: Error?
     let historyResultOverride: PracticeSongHistoryLoadResult?
+    let historyDelay: Duration
+    private var historyRequestCount = 0
 
     init(
         metadataError: Error? = nil,
         progresses: [SongPracticeProgress] = [],
-        historyResultOverride: PracticeSongHistoryLoadResult? = nil
+        historyResultOverride: PracticeSongHistoryLoadResult? = nil,
+        historyDelay: Duration = .zero
     ) {
         self.metadataError = metadataError
         self.progresses = progresses
         self.historyResultOverride = historyResultOverride
+        self.historyDelay = historyDelay
     }
 
     func load() -> PracticeProgressLoadResult { .loaded(PracticeProgressDocument()) }
     func progress(for _: PracticeSongIdentity) -> SongPracticeProgress? { nil }
-    func history(for songID: UUID) -> PracticeSongHistoryLoadResult {
+    func history(for songID: UUID) async -> PracticeSongHistoryLoadResult {
+        historyRequestCount += 1
+        if historyDelay != .zero {
+            try? await Task.sleep(for: historyDelay)
+        }
         if let historyResultOverride { return historyResultOverride }
         return .loaded(PracticeSongHistory(
             songID: songID,
@@ -713,9 +744,13 @@ private actor RecordingPracticeLaunchProgressRepository: PracticeProgressReposit
         while metadata.count < count { await Task.yield() }
     }
 
-    func loadedHistory(songID: UUID) -> PracticeSongHistory? {
-        guard case let .loaded(history) = history(for: songID) else { return nil }
+    func loadedHistory(songID: UUID) async -> PracticeSongHistory? {
+        guard case let .loaded(history) = await history(for: songID) else { return nil }
         return history
+    }
+
+    func waitUntilHistoryRequested() async {
+        while historyRequestCount == 0 { await Task.yield() }
     }
 }
 

--- a/HappyPianistAVPTests/Practice/PracticeLaunchViewModelTests.swift
+++ b/HappyPianistAVPTests/Practice/PracticeLaunchViewModelTests.swift
@@ -31,6 +31,26 @@ func practiceLaunchRegistersWithoutPreparingThenActivatesExactlyOnce() async {
 
 @MainActor
 @Test
+func practiceLaunchStopsBeforePreparationWhenPreviousProgressCannotBeSaved() async {
+    let fixture = makePracticeLaunchFixture()
+    fixture.applicator.clearStatus = .failed(message: "disk full")
+    fixture.owner.request(songID: fixture.songA)
+
+    await fixture.owner.activateCurrentRequest()
+
+    guard case let .failure(failure) = fixture.owner.state else {
+        Issue.record("Expected a typed progress-save failure")
+        return
+    }
+    #expect(failure.code == .practiceProgressSaveFailed)
+    #expect(failure.diagnosticEvent.category == .persistence)
+    #expect(await fixture.preparation.requestedSongIDs().isEmpty)
+    #expect(fixture.applicator.appliedSongIDs.isEmpty)
+    #expect(await fixture.reporter.events.last == failure.diagnosticEvent)
+}
+
+@MainActor
+@Test
 func practiceLaunchPassesExactRestorePolicyBeforeSessionApply() async {
     let songID = fixtureSongA
     let fixture = makePracticeLaunchFixture(
@@ -226,6 +246,41 @@ func practiceLaunchReturnFinishIsIdempotentAndRejectsStaleOperation() async {
     #expect(fixture.owner.requestedSongID == nil)
     #expect(fixture.owner.activationIdentity == nil)
     #expect(fixture.applicator.clearCount == 1)
+}
+
+@MainActor
+@Test
+func failedPracticeReturnRestoresTheReadyRequestForRetry() async {
+    let fixture = makePracticeLaunchFixture()
+    fixture.owner.request(songID: fixture.songA)
+    await fixture.owner.activateCurrentRequest()
+    let readyState = fixture.owner.state
+    fixture.applicator.clearStatus = .failed(message: "disk full")
+
+    let operationID = fixture.owner.beginReturn()
+    let status = await fixture.owner.finishReturn(operationID: operationID)
+
+    guard case .failed = status else {
+        Issue.record("Expected progress-save failure")
+        return
+    }
+    #expect(fixture.owner.state == readyState)
+    #expect(fixture.owner.requestedSongID == fixture.songA)
+    #expect(fixture.owner.activationIdentity?.songID == fixture.songA)
+}
+
+@MainActor
+@Test
+func abortingPracticeReturnRestoresARequestedLaunch() {
+    let fixture = makePracticeLaunchFixture()
+    fixture.owner.request(songID: fixture.songA)
+
+    let operationID = fixture.owner.beginReturn()
+    fixture.owner.abortReturn(operationID: operationID)
+
+    #expect(fixture.owner.state == .requested(songID: fixture.songA))
+    #expect(fixture.owner.requestedSongID == fixture.songA)
+    #expect(fixture.owner.activationIdentity?.songID == fixture.songA)
 }
 
 @MainActor
@@ -979,9 +1034,14 @@ private final class PracticeLaunchRecordingApplicator: PracticeLaunchApplying {
     private(set) var suspendCount = 0
     private(set) var leaveCount = 0
     let applyOutcome: PracticeLaunchApplyOutcome
+    var clearStatus: PracticeProgressSaveStatus
 
-    init(applyOutcome: PracticeLaunchApplyOutcome) {
+    init(
+        applyOutcome: PracticeLaunchApplyOutcome,
+        clearStatus: PracticeProgressSaveStatus = .saved
+    ) {
         self.applyOutcome = applyOutcome
+        self.clearStatus = clearStatus
     }
 
     func applyPreparedPracticeForLaunch(
@@ -995,9 +1055,15 @@ private final class PracticeLaunchRecordingApplicator: PracticeLaunchApplying {
         return applyOutcome
     }
 
-    func clearPreparedPracticeForLaunch() async { clearCount += 1 }
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus {
+        clearCount += 1
+        return clearStatus
+    }
     func suspendPracticeAndFlushProgress() async { suspendCount += 1 }
-    func leavePracticeStep() async { leaveCount += 1 }
+    func leavePracticeStep() async -> PracticeProgressSaveStatus {
+        leaveCount += 1
+        return .saved
+    }
 }
 
 @MainActor
@@ -1030,9 +1096,9 @@ private final class ControlledPracticeLaunchApplicator: PracticeLaunchApplying {
         applyContinuation = nil
     }
 
-    func clearPreparedPracticeForLaunch() async {}
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus { .saved }
     func suspendPracticeAndFlushProgress() async { suspendCount += 1 }
-    func leavePracticeStep() async {}
+    func leavePracticeStep() async -> PracticeProgressSaveStatus { .saved }
 }
 
 @MainActor
@@ -1057,9 +1123,9 @@ private final class AppliedThenSuspendedPracticeLaunchApplicator: PracticeLaunch
         continuation = nil
     }
 
-    func clearPreparedPracticeForLaunch() async {}
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus { .saved }
     func suspendPracticeAndFlushProgress() async {}
-    func leavePracticeStep() async {}
+    func leavePracticeStep() async -> PracticeProgressSaveStatus { .saved }
 }
 
 @MainActor
@@ -1076,9 +1142,9 @@ private final class RejectOncePracticeLaunchApplicator: PracticeLaunchApplying {
         return .applied
     }
 
-    func clearPreparedPracticeForLaunch() async {}
+    func clearPreparedPracticeForLaunch() async -> PracticeProgressSaveStatus { .saved }
     func suspendPracticeAndFlushProgress() async {}
-    func leavePracticeStep() async {}
+    func leavePracticeStep() async -> PracticeProgressSaveStatus { .saved }
 }
 
 private func makePracticeLaunchPreparedPractice(

--- a/HappyPianistAVPTests/Practice/PracticeProgressCoordinatorTests.swift
+++ b/HappyPianistAVPTests/Practice/PracticeProgressCoordinatorTests.swift
@@ -144,6 +144,27 @@ func progressCoordinatorReportsStoreFailureWithoutCrashingSession() async throws
     }
 }
 
+@Test
+func progressCoordinatorFinishFailureRetainsPendingProgressForRetry() async throws {
+    let repository = InMemoryPracticeProgressRepository(upsertError: TestProgressError.writeFailed)
+    let coordinator = PracticeProgressCoordinator(repository: repository, checkpointDelay: .seconds(60))
+    let identity = PracticeSongIdentity(songID: UUID(), scoreRevision: "r1")
+    let session = await coordinator.begin(identity: identity)
+    var progress = SongPracticeProgress(identity: identity, updatedAt: .now)
+    progress.measureFacts = [makeFacts(successes: 3)]
+    await coordinator.checkpoint(progress, generation: session.generation)
+
+    guard case .failed = await coordinator.finish(generation: session.generation) else {
+        Issue.record("Expected recoverable finish failure")
+        return
+    }
+    await repository.allowWrites()
+
+    #expect(await coordinator.finish(generation: session.generation) == .saved)
+    #expect(await repository.progress(for: identity)?.measureFacts.first?.successfulAttempts == 3)
+    #expect(await repository.upsertCount == 1)
+}
+
 private func makeFacts(successes: Int) -> MeasurePracticeFacts {
     MeasurePracticeFacts(
         sourceMeasureID: PracticeSourceMeasureID(partID: "P1", sourceMeasureIndex: 0),
@@ -163,7 +184,7 @@ private struct FixedPracticeProgressClock: PracticeProgressClockProtocol {
 
 private actor InMemoryPracticeProgressRepository: PracticeProgressRepositoryProtocol {
     private var values: [PracticeSongIdentity: SongPracticeProgress]
-    private let upsertError: Error?
+    private var upsertError: Error?
     private(set) var upsertCount = 0
 
     init(
@@ -188,6 +209,10 @@ private actor InMemoryPracticeProgressRepository: PracticeProgressRepositoryProt
             progresses: values.values.filter { $0.identity.songID == songID },
             scoreMetadata: []
         ))
+    }
+
+    func allowWrites() {
+        upsertError = nil
     }
 
     func upsert(_ progress: SongPracticeProgress) throws {

--- a/HappyPianistAVPTests/Practice/PreparedPracticeLifecycleTests.swift
+++ b/HappyPianistAVPTests/Practice/PreparedPracticeLifecycleTests.swift
@@ -135,7 +135,40 @@ func replacementStopsAndKeepsOldSessionWhenProgressCannotBeSaved() async {
     #expect(guide.practiceSessionViewModel === oldSession)
     #expect(oldSession.hasShutdown == false)
     #expect(oldSession.sessionProgress == oldProgress)
-    #expect(guide.practiceSessionReplacementErrorMessage != nil)
+    #expect(guide.practiceProgressSaveErrorMessage != nil)
+}
+
+@Test
+@MainActor
+func clearingPreparedPracticePreservesCurrentSessionWhenProgressCannotBeSaved() async {
+    let repository = FailingLifecycleProgressRepository()
+    let coordinator = PracticeProgressCoordinator(
+        repository: repository,
+        checkpointDelay: .seconds(60)
+    )
+    let appState = AppState()
+    let guide = makeLifecycleGuide(appState: appState, progressCoordinator: coordinator)
+    let prepared = makeLifecyclePreparedPractice()
+    #expect(await guide.applyPreparedPracticeForLaunch(
+        prepared,
+        restorePolicy: .freshDefaults,
+        isCurrent: { true }
+    ) == .applied)
+    guide.practiceSessionViewModel.startGuidingIfReady()
+    let session = guide.practiceSessionViewModel
+
+    let status = await guide.clearPreparedPracticeForLaunch()
+
+    guard case .failed = status else {
+        Issue.record("Expected progress-save failure")
+        return
+    }
+    #expect(guide.practiceSessionViewModel === session)
+    #expect(session.hasShutdown == false)
+    #expect(session.songIdentity == prepared.identity)
+    #expect(guide.latestPreparedPractice?.identity == prepared.identity)
+    #expect(appState.practiceSetupState.preparedPracticeIdentity == prepared.identity)
+    #expect(guide.practiceProgressSaveErrorMessage != nil)
 }
 
 @Test

--- a/HappyPianistAVPTests/Support/SongLibraryViewModelTestHarness.swift
+++ b/HappyPianistAVPTests/Support/SongLibraryViewModelTestHarness.swift
@@ -22,6 +22,9 @@ enum SongLibraryViewModelTestHarness {
         let resolvedIndexStore = indexStore ?? InMemorySongLibraryIndexStore(index: resolvedIndex)
         let resolvedFileStore = fileStore ?? InMemorySongFileStore()
         let resolvedBundledProvider = StubBundledSongLibraryProvider(entries: bundledEntries)
+        let resolvedBootstrapLoader = bootstrapLoader ?? FixedSongLibraryBootstrapLoader(
+            snapshot: .loaded(index: resolvedIndex, bundledEntries: bundledEntries)
+        )
         return SongLibraryViewModel(
             indexStore: resolvedIndexStore,
             importTransactionService: importTransactionService ?? NoopSongLibraryImportTransactionService(),
@@ -32,7 +35,7 @@ enum SongLibraryViewModelTestHarness {
             practiceProgressRepository: practiceProgressRepository ?? InMemoryPracticeProgressRepository(),
             diagnosticsReporter: diagnosticsReporter ?? NoopLibraryDiagnosticsReporter(),
             snapshotBuilder: snapshotBuilder ?? SongPracticeLibrarySnapshotBuilder(),
-            bootstrapLoader: bootstrapLoader,
+            bootstrapLoader: resolvedBootstrapLoader,
             initialSnapshot: deferInitialLoad
                 ? nil
                 : .loaded(index: resolvedIndex, bundledEntries: bundledEntries),
@@ -40,6 +43,18 @@ enum SongLibraryViewModelTestHarness {
             snapshotSettleDelay: snapshotSettleDelay,
             selectionPersistenceDelay: .zero
         )
+    }
+}
+
+private actor FixedSongLibraryBootstrapLoader: SongLibraryBootstrapLoading {
+    let snapshot: SongLibraryBootstrapSnapshot
+
+    init(snapshot: SongLibraryBootstrapSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func load() -> SongLibraryBootstrapSnapshot {
+        snapshot
     }
 }
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -115,7 +115,7 @@ selected song UUID + entry version token
 -> UUID + token + generation 仍一致时发布 snapshot state
 ```
 
-Library 返回前台时会刷新同一 selection；同一 run-loop 的 `onAppear` / active refresh 会取消并合并到最新 generation。损坏 history 只产生 `unavailable` 与 typed diagnostic，不设置全局错误，也不禁用试听或唯一开始按钮。该路径不解析曲谱、不访问 score URL、`PreparedPractice` 或 session。trailing Ornament 渲染 no selection、loading、never practiced、current、needs rebuild 与 unavailable 六类只读状态；Reduce Motion 使用静态 phase，VoiceOver 和 Differentiate Without Color 不依赖颜色传达事实。
+Library 返回前台时会刷新同一 selection；同一 run-loop 的 `onAppear` / active refresh 会取消并合并到最新 generation。损坏 history 只产生 `unavailable` 与 typed diagnostic，不设置全局错误，也不禁用试听或唯一开始按钮。该路径不解析曲谱、不访问 score URL、`PreparedPractice` 或 session。未选择曲目时不挂载 trailing Ornament；已选曲目只渲染 loading、never practiced、current、needs rebuild 与 unavailable 五类只读状态；Reduce Motion 使用静态 phase，VoiceOver 和 Differentiate Without Color 不依赖颜色传达事实。
 
 ## 本轮配置与 active range
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -29,7 +29,7 @@ bundled MusicXML 和 App 资源来自 bundle，不写入 Documents。
 4. 用户确认只回传 operation ID；actor 重新分类最新事实。indexed target 先按指纹备份旧文件再用 CAS 保留 song ID、显示名、音频、顺序和最后选择，missing target 直接修复同一 entry，filesystem orphan 备份同名未索引文件后建立新 entry。歧义目标不提供覆盖动作。
 5. CAS 或 index 保存失败时仅在 staged/backup/target 指纹仍匹配时恢复确认前文件事实；已经提交但 cleanup 失败的 journal 由下次 bootstrap 幂等收尾。
 
-只有 index 文件缺失时视为空库；零字节、空白或无法解码的 JSON 都保留原文件并阻塞读取及所有 mutation，禁止按空库继续写入。
+index 文件缺失、零字节或仅包含空白时视为空库，首次 mutation 会原子写出有效 JSON；非空但无法解码的 JSON 保留原文件并阻塞读取及所有 mutation，禁止按空库继续写入。
 
 每个导入事务目录只允许 UUID operation 目录、`journal.json`、`stage/` 与 `backup/`；`.partial` 只允许出现在 preparing 阶段。journal 只记录相对文件名、operation/song/token 标识、phase 及 staged/backup 指纹；不记录 URL、原始曲谱、错误正文或完整 index。恢复在 bootstrap 读取 index 前运行，删除或覆盖 staged、backup、target 前必须同时核对字节数和 SHA-256；符号链接、未知目录内容、文件身份变化或歧义一律阻塞启动快照发布。
 


### PR DESCRIPTION
背景：曲库索引初始化不当导致空白曲库，旧的曲库启动旁路影响性能，过期试听和练习历史未被丢弃，保存失败时未能正确处理练习进度。

变更：

- 曲库模块：修复空白曲库索引初始化，删除旧的曲库启动旁路，确保曲库导入状态更简洁。

- 练习模块：丢弃过期的试听和练习历史，保存失败时阻止练习切换与退出，确保练习进度在保存失败时得以保留。

- 诊断模块：新增保存失败的诊断码，确保用户能获得明确的错误信息。

测试：

- 导入空曲库时期望返回空库状态。

- 保存练习进度失败时期望不切换练习。

- 进行过期试听时期望丢弃相关数据。

- 导入过程中取消操作期望终止暂存任务。