### PR TITLE
docs: 统一文档中的项目名为 Amoroso

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,13 +1,15 @@
-# 🎹 HappyPianist
+# 🎹 Amoroso
 
 An AI piano companion for Apple Vision Pro that guides you step-by-step through playing sheet music, and lets you enjoy relay improvisation with an AI partner.
+
+> Note: the repository was renamed to Amoroso. The Xcode project, targets and source directories still use the `HappyPianist*` naming.
 
 [**中文**](./README.md) | English
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 ![Platform](https://img.shields.io/badge/visionOS-lightgrey)
 ![Swift](https://img.shields.io/badge/Swift-6-orange)
-[![Last Update](https://img.shields.io/github/last-commit/chiimagnus/happypianist?label=Last%20update&style=classic)](https://github.com/chiimagnus/happypianist)
+[![Last Update](https://img.shields.io/github/last-commit/chiimagnus/Amoroso?label=Last%20update&style=classic)](https://github.com/chiimagnus/Amoroso)
 
 ![scene1](docs/assets/scene1.jpg)
 
@@ -33,7 +35,7 @@ Those professional claims remain `pending evidence` until licensed multi-exporte
 
 - The repo is primarily source-code based: **requires local Xcode build** — no pre-built notarized app is provided.
 
-- The soundfont `SalC5Light2.sf2` for `HappyPianistAVP` is large and not included in the repo by default. You can download it from [GitHub Releases](https://github.com/chiimagnus/HappyPianist/releases/tag/v0.1.6-beta2) and place it at:
+- The soundfont `SalC5Light2.sf2` for `HappyPianistAVP` is large and not included in the repo by default. You can download it from [GitHub Releases](https://github.com/chiimagnus/Amoroso/releases/tag/v0.1.6-beta2) and place it at:
   - `HappyPianistAVP/Resources/Audio/SoundFonts/SalC5Light2.sf2`
 
 - Seed scores and the CoreML model are also private resources. Tests skipped because those resources are absent are not evidence that their integrations passed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# HappyPianist
+# Amoroso
 
-HappyPianist 是一个面向 Apple Vision Pro 的钢琴练习应用。它把 MusicXML 转成空间练习引导，并支持音频、蓝牙 MIDI 与虚拟钢琴三种输入方式。
+Amoroso（原 HappyPianist）是一个面向 Apple Vision Pro 的钢琴练习应用。它把 MusicXML 转成空间练习引导，并支持音频、蓝牙 MIDI 与虚拟钢琴三种输入方式。
+
+> 说明：仓库已更名为 Amoroso，Xcode 工程、target 与源码目录仍沿用 `HappyPianist*` 命名。
 
 ![scene](docs/assets/scene1.jpg)
 


### PR DESCRIPTION
## 背景

仓库已更名为 **Amoroso**，但文档层仍到处显示旧名 HappyPianist，对新来的人会造成“这到底是不是同一个项目”的困惑。

## 改了什么

- `README.md`：标题与开篇改为 Amoroso，并注明原名。
- `README.en.md`：标题改为 Amoroso；修正指向旧仓库名的链接（last-commit badge、Releases 链接）。
- 两份 README 均加一句说明：工程与目录仍沿用 `HappyPianist*` 命名。

## 没改什么（故意）

- 不动 `HappyPianist.xcodeproj`、`HappyPianistAVP/`、`HappyPianistAVPTests/` 等工程与目录命名。
- 不动任何资源路径（如 SoundFont 放置位置）。
- 不动任何代码。

工程级重命名会牵动 Xcode 工程文件与构建配置，适合在本地做，不走这个 PR。

## 遗留

`docs/overview.md` 等知识库文档中仍有旧名，可在后续单独处理。

## 验证

纯文档改动，未运行构建与测试。