### PR TITLE
Add AR hand skeleton tracking and neon hand visualization pipeline

### DIFF
--- a/HappyPianistAVP/AGENTS.md
+++ b/HappyPianistAVP/AGENTS.md
@@ -54,7 +54,7 @@
   entity.components.set(CollisionComponent(shapes: [.generateBox(size: [0.1, 0.1, 0.1])]))
   entity.components.set(InputTargetComponent())
   ```
-- **Mesh 资源:** 仅允许生成：`box`、`sphere`、`plane`、`cylinder`、`cone`。
+- **Mesh 资源:** 默认仅生成：`box`、`sphere`、`plane`、`cylinder`、`cone`。唯一例外是 `HandVisualization` 的固定容量 `LowLevelMesh`：它只更新荧光手套的既定顶点，不能在 `RealityView.update` 分配网格、加入资产/纹理，或把手部数据传出渲染边界。
 
 ### 3. 交互与输入
 - **手势:**
@@ -83,7 +83,7 @@
   - `WorldTrackingProvider`: 用于 device pose 与 world anchors。
   - `PlaneDetectionProvider`: 用于检测桌面/地面/墙等平面。
   - `SceneReconstructionProvider`: 用于环境网格与遮挡（meshing/occlusion）。
-  - `HandTrackingProvider`: 用于手部追踪（可能需要特定 entitlements）。
+  - `HandTrackingProvider`: 用于手部追踪；标准 ARKit hand tracking 通过 `NSHandsTrackingUsageDescription` 请求用户授权，不添加企业 entitlement。荧光手套保持 `.mixed` 透视与系统手部可见；追踪缺失/拒绝时仅隐藏。Simulator 的合成姿态只能留在 `HandVisualization` 的条件编译渲染路径，绝不进入 ARKit service、练习输入、持久化或诊断。
 - **Anchors:** 使用 ARKit anchor 的 `UUID` 来关联 RealityKit entities。
  
 ## RealityKit 组件参考

--- a/HappyPianistAVP/Models/Tracking/TrackedHandSkeleton.swift
+++ b/HappyPianistAVP/Models/Tracking/TrackedHandSkeleton.swift
@@ -1,0 +1,101 @@
+import simd
+
+enum TrackedHandJoint: CaseIterable, Hashable {
+    case forearmArm
+    case forearmWrist
+    case wrist
+    case thumbKnuckle
+    case thumbIntermediateBase
+    case thumbIntermediateTip
+    case thumbTip
+    case indexFingerMetacarpal
+    case indexFingerKnuckle
+    case indexFingerIntermediateBase
+    case indexFingerIntermediateTip
+    case indexFingerTip
+    case middleFingerMetacarpal
+    case middleFingerKnuckle
+    case middleFingerIntermediateBase
+    case middleFingerIntermediateTip
+    case middleFingerTip
+    case ringFingerMetacarpal
+    case ringFingerKnuckle
+    case ringFingerIntermediateBase
+    case ringFingerIntermediateTip
+    case ringFingerTip
+    case littleFingerMetacarpal
+    case littleFingerKnuckle
+    case littleFingerIntermediateBase
+    case littleFingerIntermediateTip
+    case littleFingerTip
+
+    static let fingerChains: [[Self]] = [
+        [.thumbKnuckle, .thumbIntermediateBase, .thumbIntermediateTip, .thumbTip],
+        [.indexFingerMetacarpal, .indexFingerKnuckle, .indexFingerIntermediateBase, .indexFingerIntermediateTip, .indexFingerTip],
+        [.middleFingerMetacarpal, .middleFingerKnuckle, .middleFingerIntermediateBase, .middleFingerIntermediateTip, .middleFingerTip],
+        [.ringFingerMetacarpal, .ringFingerKnuckle, .ringFingerIntermediateBase, .ringFingerIntermediateTip, .ringFingerTip],
+        [.littleFingerMetacarpal, .littleFingerKnuckle, .littleFingerIntermediateBase, .littleFingerIntermediateTip, .littleFingerTip],
+    ]
+
+    static let palmJoints: [Self] = [
+        .wrist,
+        .thumbKnuckle,
+        .indexFingerMetacarpal,
+        .middleFingerMetacarpal,
+        .ringFingerMetacarpal,
+        .littleFingerMetacarpal,
+    ]
+
+    static let renderingJoints = Set(palmJoints + fingerChains.flatMap { $0 })
+}
+
+struct TrackedHandSkeleton: Equatable {
+    var isTracked: Bool
+    var joints: [TrackedHandJoint: SIMD3<Float>]
+
+    init(
+        isTracked: Bool = false,
+        joints: [TrackedHandJoint: SIMD3<Float>] = [:]
+    ) {
+        self.isTracked = isTracked
+        self.joints = joints
+    }
+
+    var isRenderable: Bool {
+        isTracked && TrackedHandJoint.renderingJoints.allSatisfy { joints[$0] != nil }
+    }
+
+    subscript(_ joint: TrackedHandJoint) -> SIMD3<Float>? {
+        joints[joint]
+    }
+}
+
+struct HandSkeletonSnapshot: Equatable {
+    static let empty = HandSkeletonSnapshot()
+
+    var left: TrackedHandSkeleton
+    var right: TrackedHandSkeleton
+
+    init(
+        left: TrackedHandSkeleton = TrackedHandSkeleton(),
+        right: TrackedHandSkeleton = TrackedHandSkeleton()
+    ) {
+        self.left = left
+        self.right = right
+    }
+
+    subscript(hand: TrackedHandSide) -> TrackedHandSkeleton {
+        get {
+            switch hand {
+            case .left: left
+            case .right: right
+            }
+        }
+        set {
+            switch hand {
+            case .left: left = newValue
+            case .right: right = newValue
+            }
+        }
+    }
+}

--- a/HappyPianistAVP/Resources/Info.plist
+++ b/HappyPianistAVP/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSHandsTrackingUsageDescription</key>
-	<string>HappyPianist uses hand tracking to detect which piano keys you press and to advance practice steps.</string>
+	<string>HappyPianist uses hand tracking to detect piano-key contact, guide practice steps, and display your live fluorescent hand visualization.</string>
 	<key>NSWorldSensingUsageDescription</key>
 	<string>用于在 Step3 虚拟钢琴模式中检测平面位置，并在平面上显示放双手引导与虚拟键盘。</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
+++ b/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
@@ -187,9 +187,9 @@ final class ARTrackingService: ARTrackingServiceProtocol {
         sessionGeneration += 1
         stopProviderRuntime()
         activeRequirements = []
+        clearAllTrackingState()
         fingerTipUpdates.finishSubscribers()
         handSkeletonUpdates.finishSubscribers()
-        clearAllTrackingState()
         markRunningProvidersStopped()
     }
 

--- a/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
+++ b/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
@@ -24,6 +24,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
     }
 
     private(set) var fingerTipsSnapshot = FingerTipsSnapshot.empty
+    private(set) var handSkeletonSnapshot = HandSkeletonSnapshot.empty
     private(set) var worldAnchorsByID: [UUID: WorldAnchor] = [:]
     private(set) var planeAnchorsByID: [UUID: PlaneAnchor] = [:]
     private(set) var detectedPlanes: [DetectedPlane] = []
@@ -40,6 +41,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
     }
 
     private let fingerTipUpdates = CurrentValueAsyncStreamRelay(FingerTipsSnapshot.empty)
+    private let handSkeletonUpdates = CurrentValueAsyncStreamRelay(HandSkeletonSnapshot.empty)
 
     private(set) var activeRuntime: Runtime?
     private var sessionTask: Task<Void, Never>?
@@ -51,6 +53,10 @@ final class ARTrackingService: ARTrackingServiceProtocol {
 
     func fingerTipUpdatesStream() -> AsyncStream<FingerTipsSnapshot> {
         fingerTipUpdates.makeStream()
+    }
+
+    func handSkeletonUpdatesStream() -> AsyncStream<HandSkeletonSnapshot> {
+        handSkeletonUpdates.makeStream()
     }
 
     func deviceWorldTransform(atTimestamp timestamp: TimeInterval) -> simd_float4x4? {
@@ -181,6 +187,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
         stopProviderRuntime()
         activeRequirements = []
         fingerTipUpdates.finishSubscribers()
+        handSkeletonUpdates.finishSubscribers()
         clearAllTrackingState()
         markRunningProvidersStopped()
     }
@@ -204,6 +211,8 @@ final class ARTrackingService: ARTrackingServiceProtocol {
     private func clearAllTrackingState() {
         fingerTipsSnapshot = .empty
         fingerTipUpdates.yield(.empty)
+        handSkeletonSnapshot = .empty
+        handSkeletonUpdates.yield(.empty)
         worldAnchorsByID.removeAll(keepingCapacity: false)
         planeAnchorsByID.removeAll(keepingCapacity: false)
         detectedPlanes.removeAll(keepingCapacity: false)
@@ -213,6 +222,8 @@ final class ARTrackingService: ARTrackingServiceProtocol {
         if requirements.contains(.hand) == false {
             fingerTipsSnapshot = .empty
             fingerTipUpdates.yield(.empty)
+            handSkeletonSnapshot = .empty
+            handSkeletonUpdates.yield(.empty)
         }
         if requirements.contains(.world) == false {
             worldAnchorsByID.removeAll(keepingCapacity: false)
@@ -275,7 +286,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
                 guard let self else { return }
                 for await update in runtime.handTrackingProvider.anchorUpdates {
                     guard Task.isCancelled == false, sessionGeneration == generation else { return }
-                    updateFingerTips(from: update.anchor)
+                    updateHandTracking(from: update.anchor)
                 }
             }
         }
@@ -316,7 +327,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
         }
     }
 
-    private func updateFingerTips(from anchor: HandAnchor) {
+    private func updateHandTracking(from anchor: HandAnchor) {
         let side: TrackedHandSide
         switch anchor.chirality {
         case .left:
@@ -329,6 +340,24 @@ final class ARTrackingService: ARTrackingServiceProtocol {
 
         fingerTipsSnapshot[side] = anchor.isTracked ? extractHandTips(from: anchor) : HandTips()
         fingerTipUpdates.yield(fingerTipsSnapshot)
+        handSkeletonSnapshot[side] = extractHandSkeleton(from: anchor)
+        handSkeletonUpdates.yield(handSkeletonSnapshot)
+    }
+
+    private func extractHandSkeleton(from anchor: HandAnchor) -> TrackedHandSkeleton {
+        guard anchor.isTracked, let handSkeleton = anchor.handSkeleton else {
+            return TrackedHandSkeleton()
+        }
+
+        var joints: [TrackedHandJoint: SIMD3<Float>] = [:]
+        joints.reserveCapacity(TrackedHandJoint.allCases.count)
+        for jointName in TrackedHandJoint.allCases {
+            let joint = handSkeleton.joint(jointName.arkitName)
+            guard joint.isTracked else { continue }
+            let transform = anchor.originFromAnchorTransform * joint.anchorFromJointTransform
+            joints[jointName] = SIMD3<Float>(transform.columns.3.x, transform.columns.3.y, transform.columns.3.z)
+        }
+        return TrackedHandSkeleton(isTracked: true, joints: joints)
     }
 
     private func rebuildDetectedPlanes() {
@@ -400,5 +429,39 @@ final class ARTrackingService: ARTrackingServiceProtocol {
             tips.palm = palmSum / palmCount
         }
         return tips
+    }
+}
+
+private extension TrackedHandJoint {
+    var arkitName: HandSkeleton.JointName {
+        switch self {
+        case .forearmArm: .forearmArm
+        case .forearmWrist: .forearmWrist
+        case .wrist: .wrist
+        case .thumbKnuckle: .thumbKnuckle
+        case .thumbIntermediateBase: .thumbIntermediateBase
+        case .thumbIntermediateTip: .thumbIntermediateTip
+        case .thumbTip: .thumbTip
+        case .indexFingerMetacarpal: .indexFingerMetacarpal
+        case .indexFingerKnuckle: .indexFingerKnuckle
+        case .indexFingerIntermediateBase: .indexFingerIntermediateBase
+        case .indexFingerIntermediateTip: .indexFingerIntermediateTip
+        case .indexFingerTip: .indexFingerTip
+        case .middleFingerMetacarpal: .middleFingerMetacarpal
+        case .middleFingerKnuckle: .middleFingerKnuckle
+        case .middleFingerIntermediateBase: .middleFingerIntermediateBase
+        case .middleFingerIntermediateTip: .middleFingerIntermediateTip
+        case .middleFingerTip: .middleFingerTip
+        case .ringFingerMetacarpal: .ringFingerMetacarpal
+        case .ringFingerKnuckle: .ringFingerKnuckle
+        case .ringFingerIntermediateBase: .ringFingerIntermediateBase
+        case .ringFingerIntermediateTip: .ringFingerIntermediateTip
+        case .ringFingerTip: .ringFingerTip
+        case .littleFingerMetacarpal: .littleFingerMetacarpal
+        case .littleFingerKnuckle: .littleFingerKnuckle
+        case .littleFingerIntermediateBase: .littleFingerIntermediateBase
+        case .littleFingerIntermediateTip: .littleFingerIntermediateTip
+        case .littleFingerTip: .littleFingerTip
+        }
     }
 }

--- a/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
+++ b/HappyPianistAVP/Services/ARSession/ARTrackingService.swift
@@ -90,6 +90,7 @@ final class ARTrackingService: ARTrackingServiceProtocol {
         sessionGeneration += 1
         let generation = sessionGeneration
         stopProviderRuntime()
+        clearHandTrackingState()
         activeRequirements = requirements
         clearStateForDisabledProviders(requirements: requirements)
         configureInitialProviderStates(requirements: requirements)
@@ -209,21 +210,22 @@ final class ARTrackingService: ARTrackingServiceProtocol {
     }
 
     private func clearAllTrackingState() {
-        fingerTipsSnapshot = .empty
-        fingerTipUpdates.yield(.empty)
-        handSkeletonSnapshot = .empty
-        handSkeletonUpdates.yield(.empty)
+        clearHandTrackingState()
         worldAnchorsByID.removeAll(keepingCapacity: false)
         planeAnchorsByID.removeAll(keepingCapacity: false)
         detectedPlanes.removeAll(keepingCapacity: false)
     }
 
+    private func clearHandTrackingState() {
+        fingerTipsSnapshot = .empty
+        fingerTipUpdates.yield(.empty)
+        handSkeletonSnapshot = .empty
+        handSkeletonUpdates.yield(.empty)
+    }
+
     private func clearStateForDisabledProviders(requirements: ARTrackingRequirements) {
         if requirements.contains(.hand) == false {
-            fingerTipsSnapshot = .empty
-            fingerTipUpdates.yield(.empty)
-            handSkeletonSnapshot = .empty
-            handSkeletonUpdates.yield(.empty)
+            clearHandTrackingState()
         }
         if requirements.contains(.world) == false {
             worldAnchorsByID.removeAll(keepingCapacity: false)

--- a/HappyPianistAVP/Services/ARSession/ARTrackingServiceProtocol.swift
+++ b/HappyPianistAVP/Services/ARSession/ARTrackingServiceProtocol.swift
@@ -5,6 +5,7 @@ import simd
 @MainActor
 protocol ARTrackingServiceProtocol: AnyObject {
     var fingerTipsSnapshot: FingerTipsSnapshot { get }
+    var handSkeletonSnapshot: HandSkeletonSnapshot { get }
     var worldAnchorsByID: [UUID: WorldAnchor] { get }
     var planeAnchorsByID: [UUID: PlaneAnchor] { get }
     var detectedPlanes: [DetectedPlane] { get }
@@ -14,6 +15,7 @@ protocol ARTrackingServiceProtocol: AnyObject {
     var isWorldTrackingSupported: Bool { get }
 
     func fingerTipUpdatesStream() -> AsyncStream<FingerTipsSnapshot>
+    func handSkeletonUpdatesStream() -> AsyncStream<HandSkeletonSnapshot>
     func deviceWorldTransform(atTimestamp timestamp: TimeInterval) -> simd_float4x4?
     func addWorldAnchor(originFromAnchorTransform: simd_float4x4) async throws -> UUID
     func removeWorldAnchor(id: UUID) async throws

--- a/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
+++ b/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
@@ -36,12 +36,16 @@ final class NeonHandOverlayController {
         let entity: ModelEntity
     }
 
-    private let rootEntity = Entity()
+    private let rootEntity: Entity
     private var leftHand: HandRuntime?
     private var rightHand: HandRuntime?
     private var updateTask: Task<Void, Never>?
     private var hasAttachedRoot = false
     private var reduceMotionEnabled = false
+
+    init(rootEntity: Entity = Entity()) {
+        self.rootEntity = rootEntity
+    }
 
     func update(
         isEnabled: Bool,
@@ -72,6 +76,9 @@ final class NeonHandOverlayController {
 
     func reset() {
         stopUpdates()
+        while let child = rootEntity.children.first {
+            rootEntity.children.remove(child)
+        }
         rootEntity.removeFromParent()
         leftHand = nil
         rightHand = nil

--- a/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
+++ b/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
@@ -49,6 +49,11 @@ final class NeonHandOverlayController {
         reduceMotion: Bool,
         content: RealityViewContent
     ) {
+        #if targetEnvironment(simulator)
+            if reduceMotionEnabled != reduceMotion {
+                stopUpdates()
+            }
+        #endif
         reduceMotionEnabled = reduceMotion
         guard isEnabled else {
             stopUpdates()
@@ -77,11 +82,14 @@ final class NeonHandOverlayController {
         guard updateTask == nil else { return }
 
         #if targetEnvironment(simulator)
+            guard reduceMotionEnabled == false else {
+                apply(snapshot: NeonHandSimulatorPose.snapshot(phase: 0))
+                return
+            }
             updateTask = Task { @MainActor [weak self] in
                 guard let self else { return }
                 while Task.isCancelled == false {
-                    let phase: Float = reduceMotionEnabled ? 0 : Float(ProcessInfo.processInfo.systemUptime)
-                    apply(snapshot: NeonHandSimulatorPose.snapshot(phase: phase))
+                    apply(snapshot: NeonHandSimulatorPose.snapshot(phase: Float(ProcessInfo.processInfo.systemUptime)))
                     do {
                         try await Task.sleep(for: .milliseconds(33))
                     } catch {

--- a/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
+++ b/HappyPianistAVP/Services/HandVisualization/NeonHandOverlayController.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Metal
+import RealityKit
+import simd
+import SwiftUI
+import UIKit
+
+@MainActor
+final class NeonHandOverlayController {
+    private struct Vertex {
+        var position: SIMD3<Float>
+        var normal: SIMD3<Float>
+
+        static let attributes: [LowLevelMesh.Attribute] = [
+            .init(
+                semantic: .position,
+                format: .float3,
+                layoutIndex: 0,
+                offset: MemoryLayout<Self>.offset(of: \.position)!
+            ),
+            .init(
+                semantic: .normal,
+                format: .float3,
+                layoutIndex: 0,
+                offset: MemoryLayout<Self>.offset(of: \.normal)!
+            ),
+        ]
+
+        static let layouts = [
+            LowLevelMesh.Layout(bufferIndex: 0, bufferStride: MemoryLayout<Self>.stride),
+        ]
+    }
+
+    private struct HandRuntime {
+        let mesh: LowLevelMesh
+        let entity: ModelEntity
+    }
+
+    private let rootEntity = Entity()
+    private var leftHand: HandRuntime?
+    private var rightHand: HandRuntime?
+    private var updateTask: Task<Void, Never>?
+    private var hasAttachedRoot = false
+    private var reduceMotionEnabled = false
+
+    func update(
+        isEnabled: Bool,
+        trackingService: any ARTrackingServiceProtocol,
+        reduceMotion: Bool,
+        content: RealityViewContent
+    ) {
+        reduceMotionEnabled = reduceMotion
+        guard isEnabled else {
+            stopUpdates()
+            setHandsHidden()
+            return
+        }
+
+        if hasAttachedRoot == false {
+            content.add(rootEntity)
+            hasAttachedRoot = true
+        }
+        rootEntity.isEnabled = true
+        ensureHandEntities()
+        startUpdatesIfNeeded(trackingService: trackingService)
+    }
+
+    func reset() {
+        stopUpdates()
+        rootEntity.removeFromParent()
+        leftHand = nil
+        rightHand = nil
+        hasAttachedRoot = false
+    }
+
+    private func startUpdatesIfNeeded(trackingService: any ARTrackingServiceProtocol) {
+        guard updateTask == nil else { return }
+
+        #if targetEnvironment(simulator)
+            updateTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                while Task.isCancelled == false {
+                    let phase: Float = reduceMotionEnabled ? 0 : Float(ProcessInfo.processInfo.systemUptime)
+                    apply(snapshot: NeonHandSimulatorPose.snapshot(phase: phase))
+                    do {
+                        try await Task.sleep(for: .milliseconds(33))
+                    } catch {
+                        return
+                    }
+                }
+            }
+        #else
+            let updates = trackingService.handSkeletonUpdatesStream()
+            updateTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                for await snapshot in updates {
+                    guard Task.isCancelled == false else { return }
+                    apply(snapshot: snapshot)
+                }
+            }
+        #endif
+    }
+
+    private func stopUpdates() {
+        updateTask?.cancel()
+        updateTask = nil
+    }
+
+    private func ensureHandEntities() {
+        if leftHand == nil, let runtime = makeHandRuntime() {
+            rootEntity.addChild(runtime.entity)
+            leftHand = runtime
+        }
+        if rightHand == nil, let runtime = makeHandRuntime() {
+            rootEntity.addChild(runtime.entity)
+            rightHand = runtime
+        }
+    }
+
+    private func makeHandRuntime() -> HandRuntime? {
+        do {
+            var descriptor = LowLevelMesh.Descriptor()
+            descriptor.vertexAttributes = Vertex.attributes
+            descriptor.vertexLayouts = Vertex.layouts
+            descriptor.vertexCapacity = NeonHandSurface.vertexCount
+            descriptor.indexCapacity = NeonHandSurface.triangleIndices.count
+            descriptor.indexType = .uint32
+            let mesh = try LowLevelMesh(descriptor: descriptor)
+            mesh.withUnsafeMutableIndices { rawIndices in
+                let indices = rawIndices.bindMemory(to: UInt32.self)
+                for (index, value) in NeonHandSurface.triangleIndices.enumerated() {
+                    indices[index] = value
+                }
+            }
+            mesh.parts.replaceAll([
+                LowLevelMesh.Part(
+                    indexCount: NeonHandSurface.triangleIndices.count,
+                    topology: .triangle,
+                    bounds: BoundingBox(
+                        min: SIMD3<Float>(repeating: -2),
+                        max: SIMD3<Float>(repeating: 2)
+                    )
+                ),
+            ])
+
+            let entity = ModelEntity(
+                mesh: try MeshResource(from: mesh),
+                materials: [makeMaterial()]
+            )
+            entity.isEnabled = false
+            return HandRuntime(mesh: mesh, entity: entity)
+        } catch {
+            return nil
+        }
+    }
+
+    private func makeMaterial() -> PhysicallyBasedMaterial {
+        var material = PhysicallyBasedMaterial()
+        material.baseColor = .init(tint: .cyan)
+        material.blending = .transparent(opacity: 0.46)
+        material.sheen = .init(tint: .white)
+        material.emissiveColor = .init(color: .magenta)
+        material.emissiveIntensity = 1.35
+        material.roughness = 0.24
+        material.metallic = 0.08
+        return material
+    }
+
+    private func apply(snapshot: HandSkeletonSnapshot) {
+        update(leftHand, with: snapshot.left)
+        update(rightHand, with: snapshot.right)
+    }
+
+    private func update(_ runtime: HandRuntime?, with skeleton: TrackedHandSkeleton) {
+        guard let runtime else { return }
+        guard let geometry = NeonHandSurface.geometry(for: skeleton) else {
+            runtime.entity.isEnabled = false
+            return
+        }
+
+        runtime.mesh.withUnsafeMutableBytes(bufferIndex: 0) { rawBytes in
+            let vertices = rawBytes.bindMemory(to: Vertex.self)
+            for index in geometry.positions.indices {
+                vertices[index] = Vertex(
+                    position: geometry.positions[index],
+                    normal: geometry.normals[index]
+                )
+            }
+        }
+        runtime.entity.isEnabled = true
+    }
+
+    private func setHandsHidden() {
+        leftHand?.entity.isEnabled = false
+        rightHand?.entity.isEnabled = false
+    }
+}
+
+#if targetEnvironment(simulator)
+    enum NeonHandSimulatorPose {
+        static func snapshot(phase: Float) -> HandSkeletonSnapshot {
+            HandSkeletonSnapshot(
+                left: makeHand(side: .left, phase: phase),
+                right: makeHand(side: .right, phase: phase + .pi)
+            )
+        }
+
+        private static func makeHand(side: TrackedHandSide, phase: Float) -> TrackedHandSkeleton {
+            let isLeft = side == .left
+            let wrist = SIMD3<Float>(isLeft ? -0.16 : 0.16, -0.24, -0.52)
+            let inward: Float = isLeft ? 1 : -1
+            let curl = sin(phase * 1.7) * 0.007
+            var joints = Dictionary(
+                uniqueKeysWithValues: TrackedHandJoint.allCases.map { ($0, wrist) }
+            )
+            joints[.forearmArm] = wrist + SIMD3<Float>(0, -0.12, 0.04)
+            joints[.forearmWrist] = wrist + SIMD3<Float>(0, -0.05, 0.015)
+            joints[.wrist] = wrist
+            joints[.thumbKnuckle] = wrist + SIMD3<Float>(inward * 0.032, 0.020, 0)
+            joints[.thumbIntermediateBase] = wrist + SIMD3<Float>(inward * 0.050, 0.034, curl)
+            joints[.thumbIntermediateTip] = wrist + SIMD3<Float>(inward * 0.062, 0.047, curl * 1.6)
+            joints[.thumbTip] = wrist + SIMD3<Float>(inward * 0.071, 0.060, curl * 2)
+            addFinger(
+                [.indexFingerMetacarpal, .indexFingerKnuckle, .indexFingerIntermediateBase, .indexFingerIntermediateTip, .indexFingerTip],
+                start: wrist + SIMD3<Float>(inward * 0.026, 0.027, 0),
+                curl: curl,
+                joints: &joints
+            )
+            addFinger(
+                [.middleFingerMetacarpal, .middleFingerKnuckle, .middleFingerIntermediateBase, .middleFingerIntermediateTip, .middleFingerTip],
+                start: wrist + SIMD3<Float>(0, 0.031, 0),
+                curl: curl,
+                joints: &joints
+            )
+            addFinger(
+                [.ringFingerMetacarpal, .ringFingerKnuckle, .ringFingerIntermediateBase, .ringFingerIntermediateTip, .ringFingerTip],
+                start: wrist + SIMD3<Float>(inward * -0.024, 0.028, 0),
+                curl: curl,
+                joints: &joints
+            )
+            addFinger(
+                [.littleFingerMetacarpal, .littleFingerKnuckle, .littleFingerIntermediateBase, .littleFingerIntermediateTip, .littleFingerTip],
+                start: wrist + SIMD3<Float>(inward * -0.046, 0.021, 0),
+                curl: curl,
+                joints: &joints
+            )
+            return TrackedHandSkeleton(isTracked: true, joints: joints)
+        }
+
+        private static func addFinger(
+            _ chain: [TrackedHandJoint],
+            start: SIMD3<Float>,
+            curl: Float,
+            joints: inout [TrackedHandJoint: SIMD3<Float>]
+        ) {
+            for (index, joint) in chain.enumerated() {
+                let progress = Float(index)
+                joints[joint] = start + SIMD3<Float>(0, progress * 0.021, curl * progress)
+            }
+        }
+    }
+#endif

--- a/HappyPianistAVP/Services/HandVisualization/NeonHandSurface.swift
+++ b/HappyPianistAVP/Services/HandVisualization/NeonHandSurface.swift
@@ -1,0 +1,189 @@
+import simd
+
+struct NeonHandSurface {
+    struct Geometry: Equatable {
+        let positions: [SIMD3<Float>]
+        let normals: [SIMD3<Float>]
+    }
+
+    private static let ringSides = 4
+    private static let fingerChains = TrackedHandJoint.fingerChains
+    private static let palmContour = TrackedHandJoint.palmJoints
+    private static let fingerBaseRadii: [Float] = [0.014, 0.012, 0.013, 0.012, 0.010]
+    private static let palmHalfThickness: Float = 0.003
+
+    private static let ringVertexCount = fingerChains.reduce(0) { partial, chain in
+        partial + chain.count * ringSides
+    }
+    private static let palmVertexCount = (palmContour.count + 1) * 2
+    static let vertexCount = ringVertexCount + palmVertexCount + fingerChains.count
+    static let triangleIndices = makeTriangleIndices()
+
+    // ponytail: a four-sided tube and fixed palm fan keep updates at 115 vertices per hand;
+    // move this to a GPU mesh only if Vision Pro profiling shows a measurable render cost.
+    static func geometry(for skeleton: TrackedHandSkeleton) -> Geometry? {
+        guard skeleton.isRenderable,
+              let wrist = skeleton[.wrist],
+              let indexMetacarpal = skeleton[.indexFingerMetacarpal],
+              let littleMetacarpal = skeleton[.littleFingerMetacarpal]
+        else {
+            return nil
+        }
+
+        let palmNormal = unit(
+            simd_cross(indexMetacarpal - wrist, littleMetacarpal - wrist),
+            fallback: SIMD3<Float>(0, 0, 1)
+        )
+        var positions: [SIMD3<Float>] = []
+        var normals: [SIMD3<Float>] = []
+        var tipCenters: [(position: SIMD3<Float>, normal: SIMD3<Float>)] = []
+        positions.reserveCapacity(vertexCount)
+        normals.reserveCapacity(vertexCount)
+        tipCenters.reserveCapacity(fingerChains.count)
+
+        for (fingerIndex, chain) in fingerChains.enumerated() {
+            let chainPositions = chain.compactMap { skeleton[$0] }
+            guard chainPositions.count == chain.count else { return nil }
+
+            let radius = fingerBaseRadii[fingerIndex]
+            var terminalTangent = palmNormal
+            for ringIndex in chainPositions.indices {
+                let tangent = fingerTangent(
+                    positions: chainPositions,
+                    index: ringIndex,
+                    fallback: palmNormal
+                )
+                terminalTangent = tangent
+                let crossAxis = unit(
+                    simd_cross(tangent, palmNormal),
+                    fallback: simd_cross(tangent, SIMD3<Float>(0, 1, 0))
+                )
+                let upAxis = unit(simd_cross(crossAxis, tangent), fallback: palmNormal)
+                let taper = 1 - Float(ringIndex) / Float(max(1, chainPositions.count - 1)) * 0.48
+
+                for side in 0 ..< ringSides {
+                    let angle = Float(side) * .pi * 2 / Float(ringSides)
+                    let radial = crossAxis * cos(angle) + upAxis * sin(angle)
+                    positions.append(chainPositions[ringIndex] + radial * radius * taper)
+                    normals.append(radial)
+                }
+            }
+            tipCenters.append((
+                position: chainPositions.last! + terminalTangent * radius * 0.32,
+                normal: terminalTangent
+            ))
+        }
+
+        let palmPositions = palmContour.compactMap { skeleton[$0] }
+        guard palmPositions.count == palmContour.count else { return nil }
+        let palmCenter = palmPositions.reduce(SIMD3<Float>.zero, +) / Float(palmPositions.count)
+
+        positions.append(palmCenter + palmNormal * palmHalfThickness)
+        normals.append(palmNormal)
+        for position in palmPositions {
+            positions.append(position + palmNormal * palmHalfThickness)
+            normals.append(palmNormal)
+        }
+        positions.append(palmCenter - palmNormal * palmHalfThickness)
+        normals.append(-palmNormal)
+        for position in palmPositions {
+            positions.append(position - palmNormal * palmHalfThickness)
+            normals.append(-palmNormal)
+        }
+        for tip in tipCenters {
+            positions.append(tip.position)
+            normals.append(tip.normal)
+        }
+
+        guard positions.count == vertexCount, normals.count == vertexCount else { return nil }
+        return Geometry(positions: positions, normals: normals)
+    }
+
+    private static func makeTriangleIndices() -> [UInt32] {
+        var indices: [UInt32] = []
+        indices.reserveCapacity(456)
+
+        for (fingerIndex, chain) in fingerChains.enumerated() {
+            for ringIndex in 0 ..< (chain.count - 1) {
+                for side in 0 ..< ringSides {
+                    let nextSide = (side + 1) % ringSides
+                    let a = ringVertexIndex(finger: fingerIndex, ring: ringIndex, side: side)
+                    let b = ringVertexIndex(finger: fingerIndex, ring: ringIndex, side: nextSide)
+                    let c = ringVertexIndex(finger: fingerIndex, ring: ringIndex + 1, side: side)
+                    let d = ringVertexIndex(finger: fingerIndex, ring: ringIndex + 1, side: nextSide)
+                    indices += [UInt32(a), UInt32(c), UInt32(b), UInt32(b), UInt32(c), UInt32(d)]
+                }
+            }
+
+            let tipCenter = tipCenterIndex(finger: fingerIndex)
+            let lastRing = chain.count - 1
+            for side in 0 ..< ringSides {
+                let nextSide = (side + 1) % ringSides
+                indices += [
+                    UInt32(ringVertexIndex(finger: fingerIndex, ring: lastRing, side: side)),
+                    UInt32(tipCenter),
+                    UInt32(ringVertexIndex(finger: fingerIndex, ring: lastRing, side: nextSide)),
+                ]
+            }
+        }
+
+        for point in palmContour.indices {
+            let nextPoint = (point + 1) % palmContour.count
+            let front = palmFrontContourIndex(point)
+            let frontNext = palmFrontContourIndex(nextPoint)
+            let back = palmBackContourIndex(point)
+            let backNext = palmBackContourIndex(nextPoint)
+            indices += [
+                UInt32(palmFrontCenterIndex), UInt32(front), UInt32(frontNext),
+                UInt32(palmBackCenterIndex), UInt32(backNext), UInt32(back),
+                UInt32(front), UInt32(back), UInt32(frontNext),
+                UInt32(frontNext), UInt32(back), UInt32(backNext),
+            ]
+        }
+
+        return indices
+    }
+
+    private static func ringVertexIndex(finger: Int, ring: Int, side: Int) -> Int {
+        let precedingRings = fingerChains.prefix(finger).reduce(0) { partial, chain in
+            partial + chain.count
+        }
+        return (precedingRings + ring) * ringSides + side
+    }
+
+    private static let palmFrontCenterIndex = ringVertexCount
+
+    private static func palmFrontContourIndex(_ point: Int) -> Int {
+        palmFrontCenterIndex + 1 + point
+    }
+
+    private static let palmBackCenterIndex = palmFrontCenterIndex + palmContour.count + 1
+
+    private static func palmBackContourIndex(_ point: Int) -> Int {
+        palmBackCenterIndex + 1 + point
+    }
+
+    private static func tipCenterIndex(finger: Int) -> Int {
+        ringVertexCount + palmVertexCount + finger
+    }
+
+    private static func fingerTangent(
+        positions: [SIMD3<Float>],
+        index: Int,
+        fallback: SIMD3<Float>
+    ) -> SIMD3<Float> {
+        if index == positions.startIndex {
+            return unit(positions[1] - positions[0], fallback: fallback)
+        }
+        if index == positions.index(before: positions.endIndex) {
+            return unit(positions[index] - positions[index - 1], fallback: fallback)
+        }
+        return unit(positions[index + 1] - positions[index - 1], fallback: fallback)
+    }
+
+    private static func unit(_ vector: SIMD3<Float>, fallback: SIMD3<Float>) -> SIMD3<Float> {
+        let length = simd_length(vector)
+        guard length > 0.0001 else { return fallback }
+        return vector / length
+    }
+}

--- a/HappyPianistAVP/Views/Shared/ImmersiveView.swift
+++ b/HappyPianistAVP/Views/Shared/ImmersiveView.swift
@@ -7,6 +7,7 @@ struct ImmersiveView: View {
     @State private var overlayController: PianoGuideOverlayController
     @State private var calibrationOverlayController = CalibrationOverlayController()
     @State private var keyboardAxesDebugOverlayController = KeyboardAxesDebugOverlayController()
+    @State private var neonHandOverlayController = NeonHandOverlayController()
     @State private var virtualPianoOverlayController: VirtualPianoOverlayController
     @State private var gazePlaneDiskOverlayController = GazePlaneDiskOverlayController()
     @State private var virtualPerformerOverlayController: VirtualPerformerOverlayController
@@ -88,6 +89,12 @@ struct ImmersiveView: View {
             keyboardFrame: session.calibration?.keyboardFrame,
             content: content
         )
+        neonHandOverlayController.update(
+            isEnabled: viewModel.immersiveMode == .practice,
+            trackingService: viewModel.appState.arTrackingService,
+            reduceMotion: reduceMotion,
+            content: content
+        )
         overlayController.updateHighlights(
             highlightGuide: session.currentPianoHighlightGuide,
             keyboardGeometry: keyboardGeometry,
@@ -122,6 +129,7 @@ struct ImmersiveView: View {
         overlayController.reset()
         calibrationOverlayController.reset()
         keyboardAxesDebugOverlayController.reset()
+        neonHandOverlayController.reset()
         virtualPianoOverlayController.reset()
         gazePlaneDiskOverlayController.reset()
         virtualPerformerOverlayController.reset()

--- a/HappyPianistAVPTests/Calibration/CalibrationFlowViewModelTests.swift
+++ b/HappyPianistAVPTests/Calibration/CalibrationFlowViewModelTests.swift
@@ -79,6 +79,7 @@ func shutdownIsIdempotent() async {
 @MainActor
 private final class FakeARTrackingService: ARTrackingServiceProtocol {
     var fingerTipsSnapshot = FingerTipsSnapshot.empty
+    var handSkeletonSnapshot = HandSkeletonSnapshot.empty
     var worldAnchorsByID: [UUID: WorldAnchor] = [:]
     var planeAnchorsByID: [UUID: PlaneAnchor] = [:]
     var detectedPlanes: [DetectedPlane] = []
@@ -95,6 +96,13 @@ private final class FakeARTrackingService: ARTrackingServiceProtocol {
     }
 
     func fingerTipUpdatesStream() -> AsyncStream<FingerTipsSnapshot> {
+        AsyncStream { continuation in
+            continuation.yield(.empty)
+            continuation.finish()
+        }
+    }
+
+    func handSkeletonUpdatesStream() -> AsyncStream<HandSkeletonSnapshot> {
         AsyncStream { continuation in
             continuation.yield(.empty)
             continuation.finish()

--- a/HappyPianistAVPTests/Practice/PracticeLocalizationViewModelTests.swift
+++ b/HappyPianistAVPTests/Practice/PracticeLocalizationViewModelTests.swift
@@ -140,6 +140,7 @@ func worldTrackingUnsupportedFailsAndRequestsClose() async {
 @MainActor
 private final class FakeARTrackingService: ARTrackingServiceProtocol {
     var fingerTipsSnapshot = FingerTipsSnapshot.empty
+    var handSkeletonSnapshot = HandSkeletonSnapshot.empty
     var worldAnchorsByID: [UUID: WorldAnchor] = [:]
     var planeAnchorsByID: [UUID: PlaneAnchor] = [:]
     var detectedPlanes: [DetectedPlane] = []
@@ -157,6 +158,13 @@ private final class FakeARTrackingService: ARTrackingServiceProtocol {
     }
 
     func fingerTipUpdatesStream() -> AsyncStream<FingerTipsSnapshot> {
+        AsyncStream { continuation in
+            continuation.yield(.empty)
+            continuation.finish()
+        }
+    }
+
+    func handSkeletonUpdatesStream() -> AsyncStream<HandSkeletonSnapshot> {
         AsyncStream { continuation in
             continuation.yield(.empty)
             continuation.finish()

--- a/HappyPianistAVPTests/Tracking/ARGuideImmersiveLifecycleTests.swift
+++ b/HappyPianistAVPTests/Tracking/ARGuideImmersiveLifecycleTests.swift
@@ -32,6 +32,7 @@ func immersiveSuspendAndResumeAreIdempotentAndRebuildTrackingFromRequirements() 
 @MainActor
 private final class LifecycleTrackingService: ARTrackingServiceProtocol {
     var fingerTipsSnapshot = FingerTipsSnapshot.empty
+    var handSkeletonSnapshot = HandSkeletonSnapshot.empty
     var worldAnchorsByID: [UUID: WorldAnchor] = [:]
     var planeAnchorsByID: [UUID: PlaneAnchor] = [:]
     var detectedPlanes: [DetectedPlane] = []
@@ -41,11 +42,16 @@ private final class LifecycleTrackingService: ARTrackingServiceProtocol {
     var isWorldTrackingSupported = true
 
     private let relay = CurrentValueAsyncStreamRelay(FingerTipsSnapshot.empty)
+    private let handSkeletonRelay = CurrentValueAsyncStreamRelay(HandSkeletonSnapshot.empty)
     private(set) var startCalls: [ARTrackingRequirements] = []
     private(set) var stopCallCount = 0
 
     func fingerTipUpdatesStream() -> AsyncStream<FingerTipsSnapshot> {
         relay.makeStream()
+    }
+
+    func handSkeletonUpdatesStream() -> AsyncStream<HandSkeletonSnapshot> {
+        handSkeletonRelay.makeStream()
     }
 
     func deviceWorldTransform(atTimestamp _: TimeInterval) -> simd_float4x4? {
@@ -67,5 +73,6 @@ private final class LifecycleTrackingService: ARTrackingServiceProtocol {
         activeRequirements = []
         stopCallCount += 1
         relay.finishSubscribers()
+        handSkeletonRelay.finishSubscribers()
     }
 }

--- a/HappyPianistAVPTests/Tracking/ARTrackingServiceLifecycleTests.swift
+++ b/HappyPianistAVPTests/Tracking/ARTrackingServiceLifecycleTests.swift
@@ -23,3 +23,16 @@ func restartingTrackingReplacesStoppedARKitProviders() {
 
     service.stop()
 }
+
+@MainActor
+@Test
+func stoppingTrackingClearsHandSkeletonSnapshot() async {
+    let service = ARTrackingService()
+    service.start(requirements: [.hand])
+    service.stop()
+
+    #expect(service.handSkeletonSnapshot == .empty)
+
+    var iterator = service.handSkeletonUpdatesStream().makeAsyncIterator()
+    #expect(await iterator.next() == .empty)
+}

--- a/HappyPianistAVPTests/Tracking/ARTrackingServiceLifecycleTests.swift
+++ b/HappyPianistAVPTests/Tracking/ARTrackingServiceLifecycleTests.swift
@@ -28,11 +28,14 @@ func restartingTrackingReplacesStoppedARKitProviders() {
 @Test
 func stoppingTrackingClearsHandSkeletonSnapshot() async {
     let service = ARTrackingService()
+    var iterator = service.handSkeletonUpdatesStream().makeAsyncIterator()
+
+    #expect(await iterator.next() == .empty)
     service.start(requirements: [.hand])
+    #expect(await iterator.next() == .empty)
     service.stop()
 
     #expect(service.handSkeletonSnapshot == .empty)
-
-    var iterator = service.handSkeletonUpdatesStream().makeAsyncIterator()
     #expect(await iterator.next() == .empty)
+    #expect(await iterator.next() == nil)
 }

--- a/HappyPianistAVPTests/Tracking/NeonHandSimulatorPoseTests.swift
+++ b/HappyPianistAVPTests/Tracking/NeonHandSimulatorPoseTests.swift
@@ -1,8 +1,21 @@
+import RealityKit
 import Testing
 
 @testable import HappyPianistAVP
 
 #if targetEnvironment(simulator)
+    @MainActor
+    @Test
+    func neonHandOverlayResetRemovesRetainedHandEntities() {
+        let root = Entity()
+        root.addChild(Entity())
+        root.addChild(Entity())
+
+        NeonHandOverlayController(rootEntity: root).reset()
+
+        #expect(root.children.isEmpty)
+    }
+
     @Test
     func neonHandSimulatorPoseProvidesTwoRenderableHands() {
         let snapshot = NeonHandSimulatorPose.snapshot(phase: 0)

--- a/HappyPianistAVPTests/Tracking/NeonHandSimulatorPoseTests.swift
+++ b/HappyPianistAVPTests/Tracking/NeonHandSimulatorPoseTests.swift
@@ -1,0 +1,15 @@
+import Testing
+
+@testable import HappyPianistAVP
+
+#if targetEnvironment(simulator)
+    @Test
+    func neonHandSimulatorPoseProvidesTwoRenderableHands() {
+        let snapshot = NeonHandSimulatorPose.snapshot(phase: 0)
+
+        #expect(snapshot.left.isRenderable)
+        #expect(snapshot.right.isRenderable)
+        #expect((snapshot.left[.wrist]?.x ?? 0) < 0)
+        #expect((snapshot.right[.wrist]?.x ?? 0) > 0)
+    }
+#endif

--- a/HappyPianistAVPTests/Tracking/NeonHandSurfaceTests.swift
+++ b/HappyPianistAVPTests/Tracking/NeonHandSurfaceTests.swift
@@ -1,0 +1,79 @@
+import simd
+@testable import HappyPianistAVP
+import Testing
+
+@Test
+func neonHandSurfaceProducesFixedValidTopology() throws {
+    let geometry = try #require(NeonHandSurface.geometry(for: makeTrackedHandSkeleton()))
+
+    #expect(geometry.positions.count == NeonHandSurface.vertexCount)
+    #expect(geometry.normals.count == NeonHandSurface.vertexCount)
+    #expect(NeonHandSurface.triangleIndices.count.isMultiple(of: 3))
+    #expect(NeonHandSurface.triangleIndices.allSatisfy { $0 < UInt32(NeonHandSurface.vertexCount) })
+    for position in geometry.positions {
+        #expect(position.x.isFinite)
+        #expect(position.y.isFinite)
+        #expect(position.z.isFinite)
+    }
+}
+
+@Test
+func neonHandSurfaceRejectsMissingRenderedJoint() {
+    var skeleton = makeTrackedHandSkeleton()
+    skeleton.joints.removeValue(forKey: .ringFingerTip)
+
+    #expect(NeonHandSurface.geometry(for: skeleton) == nil)
+}
+
+@Test
+func neonHandSurfaceMovesWithJointPositions() throws {
+    let initial = try #require(NeonHandSurface.geometry(for: makeTrackedHandSkeleton()))
+    var movedSkeleton = makeTrackedHandSkeleton()
+    movedSkeleton.joints[.indexFingerTip] = SIMD3<Float>(-0.030, 0.135, 0.018)
+    let moved = try #require(NeonHandSurface.geometry(for: movedSkeleton))
+
+    #expect(initial.positions != moved.positions)
+}
+
+private func makeTrackedHandSkeleton() -> TrackedHandSkeleton {
+    var joints = Dictionary(
+        uniqueKeysWithValues: TrackedHandJoint.allCases.map { ($0, SIMD3<Float>.zero) }
+    )
+    joints[.wrist] = [0, 0, 0]
+    joints[.thumbKnuckle] = [-0.032, 0.020, 0]
+    joints[.thumbIntermediateBase] = [-0.047, 0.035, 0.004]
+    joints[.thumbIntermediateTip] = [-0.057, 0.048, 0.008]
+    joints[.thumbTip] = [-0.065, 0.060, 0.012]
+    addFinger(
+        [.indexFingerMetacarpal, .indexFingerKnuckle, .indexFingerIntermediateBase, .indexFingerIntermediateTip, .indexFingerTip],
+        startingAt: [-0.025, 0.026, 0],
+        joints: &joints
+    )
+    addFinger(
+        [.middleFingerMetacarpal, .middleFingerKnuckle, .middleFingerIntermediateBase, .middleFingerIntermediateTip, .middleFingerTip],
+        startingAt: [0, 0.030, 0],
+        joints: &joints
+    )
+    addFinger(
+        [.ringFingerMetacarpal, .ringFingerKnuckle, .ringFingerIntermediateBase, .ringFingerIntermediateTip, .ringFingerTip],
+        startingAt: [0.024, 0.027, 0],
+        joints: &joints
+    )
+    addFinger(
+        [.littleFingerMetacarpal, .littleFingerKnuckle, .littleFingerIntermediateBase, .littleFingerIntermediateTip, .littleFingerTip],
+        startingAt: [0.044, 0.020, 0],
+        joints: &joints
+    )
+    return TrackedHandSkeleton(isTracked: true, joints: joints)
+}
+
+private func addFinger(
+    _ chain: [TrackedHandJoint],
+    startingAt start: SIMD3<Float>,
+    joints: inout [TrackedHandJoint: SIMD3<Float>]
+) {
+    for (index, joint) in chain.enumerated() {
+        let position = start + SIMD3<Float>(0, Float(index) * 0.020, Float(index) * 0.002)
+        joints[joint] = position
+    }
+}

--- a/HappyPianistAVPTests/Tracking/TrackedHandSkeletonTests.swift
+++ b/HappyPianistAVPTests/Tracking/TrackedHandSkeletonTests.swift
@@ -1,0 +1,33 @@
+import simd
+@testable import HappyPianistAVP
+import Testing
+
+@Test
+func trackedHandJointDescribesAllARKitHandJoints() {
+    #expect(TrackedHandJoint.allCases.count == 27)
+}
+
+@Test
+func renderableSkeletonRequiresTrackingAndEveryRenderedJoint() {
+    let completeJoints = Dictionary(
+        uniqueKeysWithValues: TrackedHandJoint.renderingJoints.map {
+            ($0, SIMD3<Float>(repeating: Float($0.hashValue)))
+        }
+    )
+
+    #expect(TrackedHandSkeleton(isTracked: false, joints: completeJoints).isRenderable == false)
+    #expect(TrackedHandSkeleton(isTracked: true, joints: completeJoints).isRenderable)
+
+    var incompleteJoints = completeJoints
+    incompleteJoints.removeValue(forKey: .indexFingerTip)
+    #expect(TrackedHandSkeleton(isTracked: true, joints: incompleteJoints).isRenderable == false)
+}
+
+@Test
+func handSkeletonSnapshotKeepsHandsIndependent() {
+    var snapshot = HandSkeletonSnapshot()
+    snapshot[.left] = TrackedHandSkeleton(isTracked: true)
+
+    #expect(snapshot.left.isTracked)
+    #expect(snapshot.right.isTracked == false)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,7 @@ Models / Contracts
 | --- | --- | --- |
 | App 与窗口 | `HappyPianistAVPApp`、`AppState` | Library 是入口；preparation 与 practice 是单层 pushed window；immersive space 只承载空间内容。 |
 | 组合根 | `LiveAppGraph` | 共享的 index store、曲库 provider、progress repository、diagnostics reporter 与 practice recorder 不在 ViewModel 内重新创建。 |
+| 手部可视化 | `ARTrackingService`、`NeonHandOverlayController` | service 将实时骨骼归一为运行期快照并以 current-value async stream 发布；controller 在 `.mixed` immersive practice 中复用固定容量网格渲染荧光手套。Simulator 合成姿态只存在于 controller 的条件编译渲染路径；它不是 AR 输入、练习证据、持久化或诊断。 |
 | macOS host | `HappyPianistMacApp`、`MacAppGraph`、`MacPracticeViewModel` | 独立沙盒、空 bundled library 和初始导入入口；Mac ViewModel 只绑定 Library resolver、`PracticeRoundSessionController`、MIDI endpoint effect 与 Notation，不复制 reducer、progress 或 playback lifecycle。 |
 | 诊断根 | `Packages/HappyPianistCore/Sources/Diagnostics/` | `DiagnosticEvent`、reporter、七日文件 store、OSLog sink、损坏文件隔离与用户归档；不包含音频、AR、Practice 投影或输出指标。 |
 | 曲谱根 | `Packages/HappyPianistCore/Sources/MusicXML/` | MusicXML/MXL 解析、结构扩展、模型与安全限制；输入失败以本模块 typed error 表示，不反向依赖 Practice。 |
@@ -64,6 +65,7 @@ Models / Contracts
 - alignment、逐音 evidence、target profile、`MusicalIssue`、coaching decision 和复测关联只存在运行期。
 - 未观察、低置信度、unknown、insufficient 与 degraded capability 不得被改写成用户错误。
 - AI/system playback、旧 generation 和后台期间的事件不得进入用户 observation 或 progress。
+- 手部骨骼快照与荧光手套均为运行期渲染状态；追踪授权被拒绝、provider 不支持或手部不完整时隐藏，不以假数据替代。只有 Simulator 的渲染分支可生成合成姿态。
 - progress、metadata、session 是同一 JSON 文件中的独立 concern；调用方不得整份覆盖另两个 concern。
 - 诊断只通过 `DiagnosticsReporting` 进入系统日志和筛选后的导出日志；导出不得包含原谱、逐音输入、绝对路径、凭据或 AI 正文。
 - 主 Actor 不执行 MusicXML 解析、文件 IO、设备重活；长生命周期任务在 teardown 时取消。

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -98,6 +98,20 @@ MIDI / target audio / hand contact
 - alignment、逐音证据、target、issue、decision 和 before/after 只存在运行期；只有批准的小节聚合进入 progress。
 - coaching 每次最多选择一个有范围、来源和 completion condition 的 action；点击或 accept 不代表改善。
 
+## 手部可视化
+
+```text
+HandTrackingProvider
+  → ARTrackingService
+  → HandSkeletonSnapshot current-value async stream
+  → NeonHandOverlayController
+  → fixed-capacity LowLevelMesh / fluorescent glove
+```
+
+- 手套只在 practice 的 `.mixed` `ImmersiveSpace` 自动显示；不进入 `.full`，也不隐藏系统手部，因此真实钢琴、双手和荧光半透明轮廓可同时可见。
+- `ARTrackingService` 是唯一的真机骨骼来源；拒绝授权、不支持、停止或关节不完整时 controller 只隐藏对应手套。原始关节和派生 mesh 均不写入 progress、文件或诊断。
+- Simulator 以条件编译的合成双手仅驱动 controller 渲染，供不佩戴设备时调整视觉效果；它绝不回灌 AR service、触键判定、练习 observation 或真机降级路径。真机的追踪精度、舒适度和实时表现仍需 Apple Vision Pro 验收。
+
 ## 进度与会话
 
 ```text


### PR DESCRIPTION
## Summary

Introduce a full hand skeleton tracking pipeline for HappyPianist visionOS, enabling live hand visualization while keeping AR tracking responsibilities isolated from rendering and practice logic.

## Changes

- Added `TrackedHandSkeleton` models to represent tracked hand joints and renderable skeleton state.
- Extended `ARTrackingService` to publish hand skeleton snapshots alongside existing fingertip tracking data.
- Added hand skeleton extraction from `HandAnchor` joint transforms.
- Implemented neon hand visualization support using a dedicated rendering path.
- Added simulator-only hand pose support for visualization testing without affecting production ARKit input.
- Updated AR tracking lifecycle handling to correctly clear and restore hand tracking state.
- Updated documentation for AR architecture and data flow.

## Constraints

- Hand visualization uses a fixed `LowLevelMesh` update path and does not dynamically allocate meshes or introduce external assets during rendering.
- Synthetic simulator poses remain isolated from ARKit services, practice input, persistence, and diagnostics.
- Existing piano practice and tracking flows remain unchanged.

## Testing

Added coverage for:

- Hand skeleton model behavior
- AR tracking lifecycle
- Neon hand surface rendering
- Simulator pose behavior
- Existing calibration and practice flows